### PR TITLE
Slice 3: Bean CRUD detail/edit/delete + full-field form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Violations of these rules fail the pre-commit hook.
 - **TanStack Form** — Use `validators: { onSubmit: SomeZodSchema }` directly. No adapter needed; Zod v4 implements Standard Schema and is auto-detected (ADR-0006). In browser-mode Vitest tests, `vi` must be imported explicitly: `import { vi } from "vitest"`.
 - **Stock decrement** — Only on RoastLog create, never on edit/delete (ADR-0002).
 - **TanStack Router** — Routes live in `src/routes/`. `routeTree.gen.ts` is auto-generated; never edit it.
+- **Date parsing in domain** — Never `new Date("YYYY-MM-DD")`; it is parsed as UTC midnight and breaks `.getMonth()` etc. for users west of UTC. Build dates from local components (ADR-0007).
 
 ### Test harness
 

--- a/docs/adr/0007-local-date-parsing.md
+++ b/docs/adr/0007-local-date-parsing.md
@@ -1,0 +1,37 @@
+# ドメイン層での日付パースはローカル時刻コンポーネントで行う
+
+ドメイン関数で `YYYY-MM-DD` 形式の日付文字列を扱うときは、必ずローカル時刻のコンポーネントから `Date` を構築する。
+
+```ts
+// ✗ NG: UTC 深夜 0 時として解釈される。getMonth() 等と組み合わせるとタイムゾーンずれが発生
+const d = new Date("2026-05-01");
+
+// ✓ OK: ローカル時刻のコンポーネントで構築
+const m = "2026-05-01".match(/^(\d{4})-(\d{2})-(\d{2})$/);
+if (!m) return null;
+const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+```
+
+## なぜか
+
+`new Date("YYYY-MM-DD")` は ECMAScript 仕様で **UTC 深夜 0 時** として解釈される。一方 `.getMonth()` / `.getFullYear()` 等はローカル時刻を返す。UTC マイナス圏（UTC-1〜UTC-12）のユーザーが月初日（例: `"2026-05-01"`）を保存すると、ローカル時刻では前月末扱いになり、月差・日数差の計算が 1 ずれる。
+
+このアプリは `<input type="date">` から ISO date 文字列を直接保存するため、保存値はユーザーの暦上の日付であり、UTC との時差を含まない。**ドメイン関数はこの「暦上の日付」をそのまま扱うべき**で、UTC 解釈を経由してはならない。
+
+## 適用範囲
+
+- `src/domain/` 内のすべての日付計算関数
+- 比較用には `today` 引数を取り、テストから固定 Date を渡せる形にする（`monthsSincePurchase(purchasedAt, today)`）
+
+`src/domain/bean.ts` の `monthsSincePurchase` がこの規約の参考実装。
+
+## Considered Options
+
+- **`new Date(iso)` のまま使う（不採用）**: シンプルだが UTC- 圏で月初日にバグ。テストも `15` 日固定では検出できない
+- **`Date.UTC()` で UTC 統一（不採用）**: ユーザーの暦上の日付と UTC 日付が一致しないため、`getUTCMonth()` 等への置換が必要になり波及範囲が広い
+- **ローカル時刻コンポーネントで構築（採用）**: タイムゾーン非依存で「暦上の日付」をそのまま扱える
+
+## 関連
+
+- ADR-0004: ドメイン層を `src/domain/` に分離する
+- PR #14（CodeRabbit 指摘で発覚）

--- a/src/components/BeanCreatePage.test.tsx
+++ b/src/components/BeanCreatePage.test.tsx
@@ -1,0 +1,65 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { BeanCreatePage } from "@/components/BeanCreatePage";
+import { db } from "@/db";
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const newRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/beans/new",
+    component: BeanCreatePage,
+  });
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/beans/$beanId",
+    component: () => <div data-testid="detail-page">detail</div>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([newRoute, detailRoute]),
+    history: createMemoryHistory({ initialEntries: ["/beans/new"] }),
+  });
+
+  render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+  return router;
+}
+
+describe("BeanCreatePage", () => {
+  beforeEach(async () => {
+    await db.beans.clear();
+  });
+
+  it("登録後、保存した Bean の詳細画面へ遷移する", async () => {
+    const user = userEvent.setup();
+    const router = renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("名前")).toBeInTheDocument(),
+    );
+    await user.type(screen.getByLabelText("名前"), "コスタリカ タラズ");
+    await user.click(screen.getByRole("button", { name: "登録" }));
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toMatch(/^\/beans\/[\w-]+$/),
+    );
+    const stored = await db.beans.toArray();
+    expect(stored).toHaveLength(1);
+    expect(stored[0].name).toBe("コスタリカ タラズ");
+    expect(router.state.location.pathname).toBe(`/beans/${stored[0].id}`);
+  });
+});

--- a/src/components/BeanCreatePage.tsx
+++ b/src/components/BeanCreatePage.tsx
@@ -1,0 +1,43 @@
+import { Link, useNavigate } from "@tanstack/react-router";
+import { BeanForm } from "@/components/BeanForm";
+import { buttonVariants } from "@/components/ui/button";
+import { useCreateBean } from "@/hooks/useMutateBean";
+import type { CreateBeanInput } from "@/schemas/bean";
+
+const emptyDefaults: CreateBeanInput = {
+  name: "",
+  origin: "",
+  productName: "",
+  shopName: "",
+  purchasedAt: null,
+  importedAt: null,
+  stockG: 0,
+  note: "",
+};
+
+export function BeanCreatePage() {
+  const navigate = useNavigate();
+  const { mutateAsync } = useCreateBean();
+
+  return (
+    <div className="p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">生豆を追加</h1>
+        <Link to="/beans" className={buttonVariants({ variant: "outline" })}>
+          キャンセル
+        </Link>
+      </div>
+      <BeanForm
+        defaultValues={emptyDefaults}
+        submitLabel="登録"
+        onSubmit={async (input) => {
+          const bean = await mutateAsync(input);
+          await navigate({
+            to: "/beans/$beanId",
+            params: { beanId: bean.id },
+          });
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/BeanDetailPage.test.tsx
+++ b/src/components/BeanDetailPage.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/react-router";
 import { render, screen, waitFor } from "@testing-library/react/pure";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BeanDetailPage } from "@/components/BeanDetailPage";
 import { db } from "@/db";
 
@@ -49,7 +49,14 @@ describe("BeanDetailPage", () => {
     await db.beans.clear();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("全フィールドと購入からの経過月数を表示する", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-02"));
+
     const id = crypto.randomUUID();
     await db.beans.put({
       id,
@@ -76,7 +83,7 @@ describe("BeanDetailPage", () => {
     expect(screen.getByText("2026-04-01")).toBeInTheDocument();
     expect(screen.getByText("2026-02-15")).toBeInTheDocument();
     expect(screen.getByText("フローラルで好み")).toBeInTheDocument();
-    // 経過月数: 購入日 2026-04-01, 今日想定 2026-05-02 → 1 ヶ月
+    // 経過月数: 購入日 2026-04-01, 今日固定 2026-05-02 → 1 ヶ月
     expect(screen.getByText(/1 ヶ月/)).toBeInTheDocument();
   });
 

--- a/src/components/BeanDetailPage.test.tsx
+++ b/src/components/BeanDetailPage.test.tsx
@@ -1,0 +1,162 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BeanDetailPage } from "@/components/BeanDetailPage";
+import { db } from "@/db";
+
+function renderAt(beanId: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/beans/$beanId",
+    component: () => <BeanDetailPage beanId={beanId} />,
+  });
+  const beansListRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/beans",
+    component: () => <div data-testid="list-page">list</div>,
+  });
+  const editRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/beans/$beanId/edit",
+    component: () => <div data-testid="edit-page">edit</div>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([detailRoute, beansListRoute, editRoute]),
+    history: createMemoryHistory({ initialEntries: [`/beans/${beanId}`] }),
+  });
+
+  render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+  return router;
+}
+
+describe("BeanDetailPage", () => {
+  beforeEach(async () => {
+    await db.beans.clear();
+  });
+
+  it("全フィールドと購入からの経過月数を表示する", async () => {
+    const id = crypto.randomUUID();
+    await db.beans.put({
+      id,
+      name: "エチオピア イルガチェフェ",
+      origin: "エチオピア",
+      productName: "G1 ナチュラル",
+      shopName: "丸山珈琲",
+      purchasedAt: "2026-04-01",
+      importedAt: "2026-02-15",
+      stockG: 320,
+      bestLogId: null,
+      note: "フローラルで好み",
+    });
+
+    renderAt(id);
+
+    await waitFor(() =>
+      expect(screen.getByText("エチオピア イルガチェフェ")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("エチオピア")).toBeInTheDocument();
+    expect(screen.getByText("G1 ナチュラル")).toBeInTheDocument();
+    expect(screen.getByText("丸山珈琲")).toBeInTheDocument();
+    expect(screen.getByText("320g")).toBeInTheDocument();
+    expect(screen.getByText("2026-04-01")).toBeInTheDocument();
+    expect(screen.getByText("2026-02-15")).toBeInTheDocument();
+    expect(screen.getByText("フローラルで好み")).toBeInTheDocument();
+    // 経過月数: 購入日 2026-04-01, 今日想定 2026-05-02 → 1 ヶ月
+    expect(screen.getByText(/1 ヶ月/)).toBeInTheDocument();
+  });
+
+  it("編集リンクで /beans/$beanId/edit に遷移できる", async () => {
+    const id = crypto.randomUUID();
+    await db.beans.put({
+      id,
+      name: "ブラジル",
+      origin: "",
+      productName: "",
+      shopName: "",
+      purchasedAt: null,
+      importedAt: null,
+      stockG: 100,
+      bestLogId: null,
+      note: "",
+    });
+    const user = userEvent.setup();
+    const router = renderAt(id);
+
+    await waitFor(() =>
+      expect(screen.getByText("ブラジル")).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("link", { name: "編集" }));
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe(`/beans/${id}/edit`),
+    );
+  });
+
+  it("削除を確認すると /beans に遷移する", async () => {
+    const id = crypto.randomUUID();
+    await db.beans.put({
+      id,
+      name: "コロンビア",
+      origin: "",
+      productName: "",
+      shopName: "",
+      purchasedAt: null,
+      importedAt: null,
+      stockG: 100,
+      bestLogId: null,
+      note: "",
+    });
+    const user = userEvent.setup();
+    const router = renderAt(id);
+    await waitFor(() =>
+      expect(screen.getByText("コロンビア")).toBeInTheDocument(),
+    );
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    await user.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/beans"));
+    expect(await db.beans.get(id)).toBeUndefined();
+    confirmSpy.mockRestore();
+  });
+
+  it("削除をキャンセルするとそのまま留まる", async () => {
+    const id = crypto.randomUUID();
+    await db.beans.put({
+      id,
+      name: "ケニア",
+      origin: "",
+      productName: "",
+      shopName: "",
+      purchasedAt: null,
+      importedAt: null,
+      stockG: 100,
+      bestLogId: null,
+      note: "",
+    });
+    const user = userEvent.setup();
+    const router = renderAt(id);
+    await waitFor(() => expect(screen.getByText("ケニア")).toBeInTheDocument());
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    await user.click(screen.getByRole("button", { name: "削除" }));
+
+    expect(router.state.location.pathname).toBe(`/beans/${id}`);
+    expect(await db.beans.get(id)).toBeDefined();
+    confirmSpy.mockRestore();
+  });
+});

--- a/src/components/BeanDetailPage.tsx
+++ b/src/components/BeanDetailPage.tsx
@@ -1,0 +1,83 @@
+import { Link, useNavigate } from "@tanstack/react-router";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { monthsSincePurchase } from "@/domain/bean";
+import { useBean } from "@/hooks/useBeans";
+import { useDeleteBean } from "@/hooks/useMutateBean";
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-sm">{value || "—"}</span>
+    </div>
+  );
+}
+
+export function BeanDetailPage({ beanId }: { beanId: string }) {
+  const navigate = useNavigate();
+  const { data: bean, isLoading } = useBean(beanId);
+  const { mutateAsync: deleteBean } = useDeleteBean();
+
+  if (isLoading) return null;
+  if (!bean) {
+    return (
+      <div className="p-6">
+        <p className="text-muted-foreground">生豆が見つかりません</p>
+        <Link to="/beans" className={buttonVariants({ variant: "outline" })}>
+          一覧へ戻る
+        </Link>
+      </div>
+    );
+  }
+
+  const months = monthsSincePurchase(bean.purchasedAt, new Date());
+
+  return (
+    <div className="p-6 flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{bean.name}</h1>
+        <div className="flex gap-2">
+          <Link
+            to="/beans/$beanId/edit"
+            params={{ beanId: bean.id }}
+            className={buttonVariants({ variant: "outline" })}
+          >
+            編集
+          </Link>
+          <Button
+            variant="destructive"
+            onClick={async () => {
+              if (!window.confirm("この生豆を削除しますか？")) return;
+              await deleteBean(bean.id);
+              await navigate({ to: "/beans" });
+            }}
+          >
+            削除
+          </Button>
+        </div>
+      </div>
+
+      <section className="grid grid-cols-2 gap-4">
+        <Field label="産地" value={bean.origin} />
+        <Field label="製品名" value={bean.productName} />
+        <Field label="購入店" value={bean.shopName} />
+        <Field label="在庫" value={`${bean.stockG}g`} />
+        <Field label="購入日" value={bean.purchasedAt ?? ""} />
+        <Field label="輸入時期" value={bean.importedAt ?? ""} />
+        <Field
+          label="購入からの経過月数"
+          value={months === null ? "" : `${months} ヶ月`}
+        />
+      </section>
+
+      <section>
+        <h2 className="mb-1 text-xs text-muted-foreground">メモ</h2>
+        <p className="text-sm whitespace-pre-wrap">{bean.note || "—"}</p>
+      </section>
+
+      <section className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+        RoastLog 履歴・BestRecipe は次のスライスで実装
+      </section>
+    </div>
+  );
+}

--- a/src/components/BeanEditPage.test.tsx
+++ b/src/components/BeanEditPage.test.tsx
@@ -1,0 +1,83 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { BeanEditPage } from "@/components/BeanEditPage";
+import { db } from "@/db";
+
+function renderAt(beanId: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const editRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/beans/$beanId/edit",
+    component: () => <BeanEditPage beanId={beanId} />,
+  });
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/beans/$beanId",
+    component: () => <div data-testid="detail-page">detail</div>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([editRoute, detailRoute]),
+    history: createMemoryHistory({ initialEntries: [`/beans/${beanId}/edit`] }),
+  });
+
+  render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+  return router;
+}
+
+describe("BeanEditPage", () => {
+  beforeEach(async () => {
+    await db.beans.clear();
+  });
+
+  it("既存値を初期表示し、stockG を変更して保存すると詳細画面へ遷移する", async () => {
+    const id = crypto.randomUUID();
+    await db.beans.put({
+      id,
+      name: "ブラジル セラード",
+      origin: "ブラジル",
+      productName: "",
+      shopName: "",
+      purchasedAt: null,
+      importedAt: null,
+      stockG: 200,
+      bestLogId: null,
+      note: "",
+    });
+
+    const user = userEvent.setup();
+    const router = renderAt(id);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText<HTMLInputElement>("名前").value).toBe(
+        "ブラジル セラード",
+      ),
+    );
+
+    const stockInput = screen.getByLabelText<HTMLInputElement>("在庫 (g)");
+    await user.clear(stockInput);
+    await user.type(stockInput, "150");
+
+    await user.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe(`/beans/${id}`),
+    );
+    const updated = await db.beans.get(id);
+    expect(updated?.stockG).toBe(150);
+  });
+});

--- a/src/components/BeanEditPage.tsx
+++ b/src/components/BeanEditPage.tsx
@@ -1,0 +1,61 @@
+import { Link, useNavigate } from "@tanstack/react-router";
+import { BeanForm } from "@/components/BeanForm";
+import { buttonVariants } from "@/components/ui/button";
+import { useBean } from "@/hooks/useBeans";
+import { useUpdateBean } from "@/hooks/useMutateBean";
+
+export function BeanEditPage({ beanId }: { beanId: string }) {
+  const navigate = useNavigate();
+  const { data: bean, isLoading } = useBean(beanId);
+  const { mutateAsync: updateBean } = useUpdateBean();
+
+  if (isLoading) return null;
+  if (!bean) {
+    return (
+      <div className="p-6">
+        <p className="text-muted-foreground">生豆が見つかりません</p>
+        <Link to="/beans" className={buttonVariants({ variant: "outline" })}>
+          一覧へ戻る
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{bean.name} を編集</h1>
+        <Link
+          to="/beans/$beanId"
+          params={{ beanId: bean.id }}
+          className={buttonVariants({ variant: "outline" })}
+        >
+          キャンセル
+        </Link>
+      </div>
+      <BeanForm
+        defaultValues={{
+          name: bean.name,
+          origin: bean.origin,
+          productName: bean.productName,
+          shopName: bean.shopName,
+          purchasedAt: bean.purchasedAt,
+          importedAt: bean.importedAt,
+          stockG: bean.stockG,
+          note: bean.note,
+        }}
+        submitLabel="保存"
+        onSubmit={async (input) => {
+          await updateBean({
+            ...bean,
+            ...input,
+          });
+          await navigate({
+            to: "/beans/$beanId",
+            params: { beanId: bean.id },
+          });
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/BeanForm.test.tsx
+++ b/src/components/BeanForm.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { BeanForm } from "@/components/BeanForm";
+import type { CreateBeanInput } from "@/schemas/bean";
+
+const emptyDefaults: CreateBeanInput = {
+  name: "",
+  origin: "",
+  productName: "",
+  shopName: "",
+  purchasedAt: null,
+  importedAt: null,
+  stockG: 0,
+  note: "",
+};
+
+describe("BeanForm", () => {
+  it("全フィールドを入力して送信できる", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <BeanForm
+        defaultValues={emptyDefaults}
+        onSubmit={onSubmit}
+        submitLabel="登録"
+      />,
+    );
+
+    await user.type(screen.getByLabelText("名前"), "エチオピア イルガチェフェ");
+    await user.type(screen.getByLabelText("産地"), "エチオピア");
+    await user.type(screen.getByLabelText("製品名"), "G1 ナチュラル");
+    await user.type(screen.getByLabelText("購入店"), "丸山珈琲");
+    await user.type(screen.getByLabelText("購入日"), "2024-01-15");
+    await user.type(screen.getByLabelText("輸入時期"), "2023-12-01");
+    await user.clear(screen.getByLabelText("在庫 (g)"));
+    await user.type(screen.getByLabelText("在庫 (g)"), "500");
+    await user.type(screen.getByLabelText("メモ"), "test note");
+
+    await user.click(screen.getByRole("button", { name: "登録" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        name: "エチオピア イルガチェフェ",
+        origin: "エチオピア",
+        productName: "G1 ナチュラル",
+        shopName: "丸山珈琲",
+        purchasedAt: "2024-01-15",
+        importedAt: "2023-12-01",
+        stockG: 500,
+        note: "test note",
+      });
+    });
+  });
+
+  it("name が空のまま送信するとバリデーションエラーが表示される", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <BeanForm
+        defaultValues={emptyDefaults}
+        onSubmit={onSubmit}
+        submitLabel="登録"
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "登録" }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("defaultValues を初期値として表示する", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <BeanForm
+        defaultValues={{
+          ...emptyDefaults,
+          name: "ブラジル セラード",
+          stockG: 250,
+        }}
+        onSubmit={onSubmit}
+        submitLabel="保存"
+      />,
+    );
+    expect(screen.getByLabelText<HTMLInputElement>("名前").value).toBe(
+      "ブラジル セラード",
+    );
+    expect(screen.getByLabelText<HTMLInputElement>("在庫 (g)").value).toBe(
+      "250",
+    );
+  });
+});

--- a/src/components/BeanForm.test.tsx
+++ b/src/components/BeanForm.test.tsx
@@ -53,7 +53,7 @@ describe("BeanForm", () => {
     });
   });
 
-  it("name が空のまま送信するとバリデーションエラーが表示される", async () => {
+  it("name が空のまま送信するとバリデーションエラーメッセージが表示される", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     render(
@@ -65,7 +65,9 @@ describe("BeanForm", () => {
     );
     await user.click(screen.getByRole("button", { name: "登録" }));
 
-    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("名前は必須です"),
+    );
     expect(onSubmit).not.toHaveBeenCalled();
   });
 

--- a/src/components/BeanForm.tsx
+++ b/src/components/BeanForm.tsx
@@ -1,0 +1,186 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { CreateBeanInput } from "@/schemas/bean";
+
+const FormSchema = z.object({
+  name: z.string().min(1, "名前は必須です"),
+  origin: z.string(),
+  productName: z.string(),
+  shopName: z.string(),
+  purchasedAt: z.string(),
+  importedAt: z.string(),
+  stockG: z.number(),
+  note: z.string(),
+});
+
+type FormValues = z.infer<typeof FormSchema>;
+
+function toFormValues(input: CreateBeanInput): FormValues {
+  return {
+    name: input.name,
+    origin: input.origin,
+    productName: input.productName,
+    shopName: input.shopName,
+    purchasedAt: input.purchasedAt ?? "",
+    importedAt: input.importedAt ?? "",
+    stockG: input.stockG,
+    note: input.note,
+  };
+}
+
+function toCreateInput(values: FormValues): CreateBeanInput {
+  return {
+    ...values,
+    purchasedAt: values.purchasedAt === "" ? null : values.purchasedAt,
+    importedAt: values.importedAt === "" ? null : values.importedAt,
+  };
+}
+
+export function BeanForm({
+  defaultValues,
+  onSubmit,
+  submitLabel,
+}: {
+  defaultValues: CreateBeanInput;
+  onSubmit: (input: CreateBeanInput) => void | Promise<void>;
+  submitLabel: string;
+}) {
+  const form = useForm({
+    defaultValues: toFormValues(defaultValues),
+    validators: { onSubmit: FormSchema },
+    onSubmit: async ({ value }) => {
+      await onSubmit(toCreateInput(value));
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="flex flex-col gap-4"
+    >
+      <form.Field name="name">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="bean-name">名前</Label>
+            <Input
+              id="bean-name"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+            {field.state.meta.errors.map((err) => (
+              <span
+                key={String(err)}
+                role="alert"
+                className="text-sm text-destructive"
+              >
+                {String(err)}
+              </span>
+            ))}
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="origin">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="bean-origin">産地</Label>
+            <Input
+              id="bean-origin"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="productName">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="bean-product-name">製品名</Label>
+            <Input
+              id="bean-product-name"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="shopName">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="bean-shop-name">購入店</Label>
+            <Input
+              id="bean-shop-name"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="purchasedAt">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="bean-purchased-at">購入日</Label>
+            <Input
+              id="bean-purchased-at"
+              type="date"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="importedAt">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="bean-imported-at">輸入時期</Label>
+            <Input
+              id="bean-imported-at"
+              type="date"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="stockG">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="bean-stock-g">在庫 (g)</Label>
+            <Input
+              id="bean-stock-g"
+              type="number"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(Number(e.target.value))}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="note">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="bean-note">メモ</Label>
+            <Input
+              id="bean-note"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      <Button type="submit">{submitLabel}</Button>
+    </form>
+  );
+}

--- a/src/components/BeanForm.tsx
+++ b/src/components/BeanForm.tsx
@@ -73,15 +73,17 @@ export function BeanForm({
               value={field.state.value}
               onChange={(e) => field.handleChange(e.target.value)}
             />
-            {field.state.meta.errors.map((err) => (
-              <span
-                key={String(err)}
-                role="alert"
-                className="text-sm text-destructive"
-              >
-                {String(err)}
-              </span>
-            ))}
+            {field.state.meta.errors.map((err) =>
+              err ? (
+                <span
+                  key={err.message}
+                  role="alert"
+                  className="text-sm text-destructive"
+                >
+                  {err.message}
+                </span>
+              ) : null,
+            )}
           </div>
         )}
       </form.Field>

--- a/src/components/BeanListPage.test.tsx
+++ b/src/components/BeanListPage.test.tsx
@@ -1,20 +1,51 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
 import { render, screen, waitFor } from "@testing-library/react/pure";
 import userEvent from "@testing-library/user-event";
-import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { BeanListPage } from "@/components/BeanListPage";
 import { db } from "@/db";
 
-function makeWrapper(qc: QueryClient) {
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-  };
-}
-
 function renderPage() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  render(<BeanListPage />, { wrapper: makeWrapper(qc) });
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const beansIndexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/beans",
+    component: BeanListPage,
+  });
+  const beansNewRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/beans/new",
+    component: () => <div data-testid="new-page">new</div>,
+  });
+  const beanDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/beans/$beanId",
+    component: () => <div data-testid="detail-page">detail</div>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([
+      beansIndexRoute,
+      beansNewRoute,
+      beanDetailRoute,
+    ]),
+    history: createMemoryHistory({ initialEntries: ["/beans"] }),
+  });
+
+  render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+  return router;
 }
 
 describe("BeanListPage", () => {
@@ -29,38 +60,67 @@ describe("BeanListPage", () => {
     );
   });
 
-  it("ダイアログから生豆を登録すると一覧に表示される", async () => {
-    const user = userEvent.setup();
-    renderPage();
+  it("登録済み Bean が一覧に表示される（name, origin, stockG）", async () => {
+    await db.beans.put({
+      id: crypto.randomUUID(),
+      name: "エチオピア イルガチェフェ",
+      origin: "エチオピア",
+      productName: "G1",
+      shopName: "",
+      purchasedAt: null,
+      importedAt: null,
+      stockG: 500,
+      bestLogId: null,
+      note: "",
+    });
 
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("エチオピア イルガチェフェ")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/エチオピア$/)).toBeInTheDocument();
+    expect(screen.getByText("在庫: 500g")).toBeInTheDocument();
+  });
+
+  it("「生豆を追加」ボタンで /beans/new へ遷移する", async () => {
+    const user = userEvent.setup();
+    const router = renderPage();
     await waitFor(() =>
       expect(screen.getByText("生豆が登録されていません")).toBeInTheDocument(),
     );
 
-    await user.click(screen.getByRole("button", { name: "生豆を追加" }));
-
-    await user.type(screen.getByLabelText("名前"), "エチオピア イルガチェフェ");
-    await user.type(screen.getByLabelText("在庫 (g)"), "500");
-
-    await user.click(screen.getByRole("button", { name: "登録" }));
+    await user.click(screen.getByRole("link", { name: "生豆を追加" }));
 
     await waitFor(() =>
-      expect(screen.getByText("エチオピア イルガチェフェ")).toBeInTheDocument(),
+      expect(router.state.location.pathname).toBe("/beans/new"),
     );
   });
 
-  it("name が空のまま登録するとバリデーションエラーが表示される", async () => {
+  it("カードをクリックすると詳細画面 /beans/$beanId に遷移する", async () => {
+    const id = crypto.randomUUID();
+    await db.beans.put({
+      id,
+      name: "ブラジル セラード",
+      origin: "ブラジル",
+      productName: "",
+      shopName: "",
+      purchasedAt: null,
+      importedAt: null,
+      stockG: 200,
+      bestLogId: null,
+      note: "",
+    });
+
     const user = userEvent.setup();
-    renderPage();
+    const router = renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("ブラジル セラード")).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("link", { name: /ブラジル セラード/ }));
 
     await waitFor(() =>
-      expect(
-        screen.getByRole("button", { name: "生豆を追加" }),
-      ).toBeInTheDocument(),
+      expect(router.state.location.pathname).toBe(`/beans/${id}`),
     );
-    await user.click(screen.getByRole("button", { name: "生豆を追加" }));
-    await user.click(screen.getByRole("button", { name: "登録" }));
-
-    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
   });
 });

--- a/src/components/BeanListPage.tsx
+++ b/src/components/BeanListPage.tsx
@@ -1,106 +1,9 @@
-import { useForm } from "@tanstack/react-form";
-import { useState } from "react";
-import { z } from "zod";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { Link } from "@tanstack/react-router";
+import { buttonVariants } from "@/components/ui/button";
 import { useBeans } from "@/hooks/useBeans";
-import { useCreateBean } from "@/hooks/useMutateBean";
-
-function CreateBeanDialog({
-  open,
-  onOpenChange,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) {
-  const { mutateAsync } = useCreateBean();
-  const form = useForm({
-    defaultValues: { name: "", stockG: 0 },
-    validators: {
-      onSubmit: z.object({
-        name: z.string().min(1, "名前は必須です"),
-        stockG: z.number(),
-      }),
-    },
-    onSubmit: async ({ value }) => {
-      await mutateAsync({
-        name: value.name,
-        stockG: value.stockG,
-        origin: "",
-        productName: "",
-        shopName: "",
-        purchasedAt: null,
-        importedAt: null,
-        note: "",
-      });
-      onOpenChange(false);
-    },
-  });
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>生豆を追加</DialogTitle>
-        </DialogHeader>
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            form.handleSubmit();
-          }}
-          className="flex flex-col gap-4"
-        >
-          <form.Field name="name">
-            {(field) => (
-              <div className="flex flex-col gap-1">
-                <Label htmlFor="name">名前</Label>
-                <Input
-                  id="name"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-                {field.state.meta.errors.map((err) => (
-                  <span
-                    key={String(err)}
-                    role="alert"
-                    className="text-sm text-destructive"
-                  >
-                    {String(err)}
-                  </span>
-                ))}
-              </div>
-            )}
-          </form.Field>
-          <form.Field name="stockG">
-            {(field) => (
-              <div className="flex flex-col gap-1">
-                <Label htmlFor="stockG">在庫 (g)</Label>
-                <Input
-                  id="stockG"
-                  type="number"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(Number(e.target.value))}
-                />
-              </div>
-            )}
-          </form.Field>
-          <Button type="submit">登録</Button>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
 
 export function BeanListPage() {
   const { data: beans, isLoading } = useBeans();
-  const [open, setOpen] = useState(false);
 
   if (isLoading) return null;
 
@@ -108,7 +11,9 @@ export function BeanListPage() {
     <div className="p-6">
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-2xl font-bold">生豆</h1>
-        <Button onClick={() => setOpen(true)}>生豆を追加</Button>
+        <Link to="/beans/new" className={buttonVariants()}>
+          生豆を追加
+        </Link>
       </div>
 
       {beans?.length === 0 ? (
@@ -116,17 +21,24 @@ export function BeanListPage() {
       ) : (
         <ul className="flex flex-col gap-2">
           {beans?.map((bean) => (
-            <li key={bean.id} className="p-4 border rounded-lg">
-              <p className="font-medium">{bean.name}</p>
-              <p className="text-sm text-muted-foreground">
-                在庫: {bean.stockG}g
-              </p>
+            <li key={bean.id}>
+              <Link
+                to="/beans/$beanId"
+                params={{ beanId: bean.id }}
+                className="block p-4 border rounded-lg hover:bg-accent"
+              >
+                <p className="font-medium">{bean.name}</p>
+                {bean.origin && (
+                  <p className="text-sm text-muted-foreground">{bean.origin}</p>
+                )}
+                <p className="text-sm text-muted-foreground">
+                  在庫: {bean.stockG}g
+                </p>
+              </Link>
             </li>
           ))}
         </ul>
       )}
-
-      <CreateBeanDialog open={open} onOpenChange={setOpen} />
     </div>
   );
 }

--- a/src/domain/bean.test.ts
+++ b/src/domain/bean.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { monthsSincePurchase } from "@/domain/bean";
+
+describe("monthsSincePurchase", () => {
+  it("purchasedAt が null なら null を返す", () => {
+    expect(monthsSincePurchase(null, new Date("2026-05-02"))).toBeNull();
+  });
+
+  it("購入月と同じ月なら 0", () => {
+    expect(monthsSincePurchase("2026-05-15", new Date("2026-05-02"))).toBe(0);
+  });
+
+  it("1 ヶ月後は 1", () => {
+    expect(monthsSincePurchase("2026-04-15", new Date("2026-05-02"))).toBe(1);
+  });
+
+  it("年をまたぐ場合も月差で返す（13 ヶ月）", () => {
+    expect(monthsSincePurchase("2025-04-15", new Date("2026-05-02"))).toBe(13);
+  });
+
+  it("不正な日付文字列は null を返す", () => {
+    expect(
+      monthsSincePurchase("not-a-date", new Date("2026-05-02")),
+    ).toBeNull();
+  });
+});

--- a/src/domain/bean.test.ts
+++ b/src/domain/bean.test.ts
@@ -18,6 +18,13 @@ describe("monthsSincePurchase", () => {
     expect(monthsSincePurchase("2025-04-15", new Date("2026-05-02"))).toBe(13);
   });
 
+  it("月初日（01）でもタイムゾーンに依らず正しく月差を返す", () => {
+    // 同月の月初日に購入 → 0 ヶ月
+    expect(monthsSincePurchase("2026-05-01", new Date(2026, 4, 2))).toBe(0);
+    // 前月の月初日に購入 → 1 ヶ月
+    expect(monthsSincePurchase("2026-04-01", new Date(2026, 4, 2))).toBe(1);
+  });
+
   it("不正な日付文字列は null を返す", () => {
     expect(
       monthsSincePurchase("not-a-date", new Date("2026-05-02")),

--- a/src/domain/bean.ts
+++ b/src/domain/bean.ts
@@ -3,8 +3,9 @@ export function monthsSincePurchase(
   today: Date,
 ): number | null {
   if (purchasedAt === null) return null;
-  const purchased = new Date(purchasedAt);
-  if (Number.isNaN(purchased.getTime())) return null;
+  const m = purchasedAt.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return null;
+  const purchased = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
   return (
     (today.getFullYear() - purchased.getFullYear()) * 12 +
     (today.getMonth() - purchased.getMonth())

--- a/src/domain/bean.ts
+++ b/src/domain/bean.ts
@@ -1,0 +1,12 @@
+export function monthsSincePurchase(
+  purchasedAt: string | null,
+  today: Date,
+): number | null {
+  if (purchasedAt === null) return null;
+  const purchased = new Date(purchasedAt);
+  if (Number.isNaN(purchased.getTime())) return null;
+  return (
+    (today.getFullYear() - purchased.getFullYear()) * 12 +
+    (today.getMonth() - purchased.getMonth())
+  );
+}

--- a/src/hooks/useBeans.test.tsx
+++ b/src/hooks/useBeans.test.tsx
@@ -3,7 +3,7 @@ import { act, renderHook, waitFor } from "@testing-library/react/pure";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { db } from "@/db";
-import { useBeans } from "@/hooks/useBeans";
+import { useBean, useBeans } from "@/hooks/useBeans";
 import {
   useCreateBean,
   useDeleteBean,
@@ -86,6 +86,42 @@ describe("useBeans", () => {
       del.current.mutate(id);
     });
     await waitFor(() => expect(beans.current.data).toHaveLength(0));
+  });
+
+  it("useBean(id) は単一 Bean を返す", async () => {
+    const qc = makeQc();
+    const wrapper = makeWrapper(qc);
+    const { result: beans } = renderHook(() => useBeans(), { wrapper });
+    const { result: create } = renderHook(() => useCreateBean(), { wrapper });
+
+    await waitFor(() => expect(beans.current.isLoading).toBe(false));
+
+    await act(async () => {
+      create.current.mutate({
+        name: "ケニア キアンビリ",
+        origin: "ケニア",
+        productName: "AA",
+        shopName: "",
+        purchasedAt: null,
+        importedAt: null,
+        stockG: 400,
+        note: "",
+      });
+    });
+    await waitFor(() => expect(beans.current.data).toHaveLength(1));
+    const id = beans.current.data?.[0].id ?? "";
+
+    const { result: bean } = renderHook(() => useBean(id), { wrapper });
+    await waitFor(() => expect(bean.current.isLoading).toBe(false));
+    expect(bean.current.data?.name).toBe("ケニア キアンビリ");
+  });
+
+  it("useBean に存在しない id を渡すと undefined を返す", async () => {
+    const { result } = renderHook(() => useBean("missing-id"), {
+      wrapper: makeWrapper(makeQc()),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toBeNull();
   });
 
   it("useUpdateBean で変更が useBeans に反映される", async () => {

--- a/src/hooks/useBeans.test.tsx
+++ b/src/hooks/useBeans.test.tsx
@@ -116,7 +116,7 @@ describe("useBeans", () => {
     expect(bean.current.data?.name).toBe("ケニア キアンビリ");
   });
 
-  it("useBean に存在しない id を渡すと undefined を返す", async () => {
+  it("useBean に存在しない id を渡すと null を返す", async () => {
     const { result } = renderHook(() => useBean("missing-id"), {
       wrapper: makeWrapper(makeQc()),
     });

--- a/src/hooks/useBeans.ts
+++ b/src/hooks/useBeans.ts
@@ -10,3 +10,10 @@ export function useBeans() {
     queryFn: () => repo.findAll(),
   });
 }
+
+export function useBean(id: string) {
+  return useQuery({
+    queryKey: ["beans", id],
+    queryFn: async () => (await repo.findById(id)) ?? null,
+  });
+}

--- a/src/hooks/useMutateBean.ts
+++ b/src/hooks/useMutateBean.ts
@@ -8,9 +8,14 @@ const repo = new BeanRepository(db.beans);
 export function useCreateBean() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async (input: CreateBeanInput) => {
-      const bean = { ...input, id: crypto.randomUUID(), bestLogId: null };
+    mutationFn: async (input: CreateBeanInput): Promise<Bean> => {
+      const bean: Bean = {
+        ...input,
+        id: crypto.randomUUID(),
+        bestLogId: null,
+      };
       await repo.save(bean);
+      return bean;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["beans"] }),
   });

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,33 +10,84 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as BeansIndexRouteImport } from './routes/beans.index'
+import { Route as BeansNewRouteImport } from './routes/beans.new'
+import { Route as BeansBeanIdIndexRouteImport } from './routes/beans.$beanId.index'
+import { Route as BeansBeanIdEditRouteImport } from './routes/beans.$beanId.edit'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BeansIndexRoute = BeansIndexRouteImport.update({
+  id: '/beans/',
+  path: '/beans/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BeansNewRoute = BeansNewRouteImport.update({
+  id: '/beans/new',
+  path: '/beans/new',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BeansBeanIdIndexRoute = BeansBeanIdIndexRouteImport.update({
+  id: '/beans/$beanId/',
+  path: '/beans/$beanId/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BeansBeanIdEditRoute = BeansBeanIdEditRouteImport.update({
+  id: '/beans/$beanId/edit',
+  path: '/beans/$beanId/edit',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/beans/new': typeof BeansNewRoute
+  '/beans/': typeof BeansIndexRoute
+  '/beans/$beanId/edit': typeof BeansBeanIdEditRoute
+  '/beans/$beanId/': typeof BeansBeanIdIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/beans/new': typeof BeansNewRoute
+  '/beans': typeof BeansIndexRoute
+  '/beans/$beanId/edit': typeof BeansBeanIdEditRoute
+  '/beans/$beanId': typeof BeansBeanIdIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/beans/new': typeof BeansNewRoute
+  '/beans/': typeof BeansIndexRoute
+  '/beans/$beanId/edit': typeof BeansBeanIdEditRoute
+  '/beans/$beanId/': typeof BeansBeanIdIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths:
+    | '/'
+    | '/beans/new'
+    | '/beans/'
+    | '/beans/$beanId/edit'
+    | '/beans/$beanId/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/beans/new' | '/beans' | '/beans/$beanId/edit' | '/beans/$beanId'
+  id:
+    | '__root__'
+    | '/'
+    | '/beans/new'
+    | '/beans/'
+    | '/beans/$beanId/edit'
+    | '/beans/$beanId/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  BeansNewRoute: typeof BeansNewRoute
+  BeansIndexRoute: typeof BeansIndexRoute
+  BeansBeanIdEditRoute: typeof BeansBeanIdEditRoute
+  BeansBeanIdIndexRoute: typeof BeansBeanIdIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -48,11 +99,43 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/beans/': {
+      id: '/beans/'
+      path: '/beans'
+      fullPath: '/beans/'
+      preLoaderRoute: typeof BeansIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/beans/new': {
+      id: '/beans/new'
+      path: '/beans/new'
+      fullPath: '/beans/new'
+      preLoaderRoute: typeof BeansNewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/beans/$beanId/': {
+      id: '/beans/$beanId/'
+      path: '/beans/$beanId'
+      fullPath: '/beans/$beanId/'
+      preLoaderRoute: typeof BeansBeanIdIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/beans/$beanId/edit': {
+      id: '/beans/$beanId/edit'
+      path: '/beans/$beanId/edit'
+      fullPath: '/beans/$beanId/edit'
+      preLoaderRoute: typeof BeansBeanIdEditRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  BeansNewRoute: BeansNewRoute,
+  BeansIndexRoute: BeansIndexRoute,
+  BeansBeanIdEditRoute: BeansBeanIdEditRoute,
+  BeansBeanIdIndexRoute: BeansBeanIdIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/beans.$beanId.edit.tsx
+++ b/src/routes/beans.$beanId.edit.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { BeanEditPage } from "@/components/BeanEditPage";
+
+export const Route = createFileRoute("/beans/$beanId/edit")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { beanId } = Route.useParams();
+  return <BeanEditPage beanId={beanId} />;
+}

--- a/src/routes/beans.$beanId.index.tsx
+++ b/src/routes/beans.$beanId.index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { BeanDetailPage } from "@/components/BeanDetailPage";
+
+export const Route = createFileRoute("/beans/$beanId/")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { beanId } = Route.useParams();
+  return <BeanDetailPage beanId={beanId} />;
+}

--- a/src/routes/beans.index.tsx
+++ b/src/routes/beans.index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { BeanListPage } from "@/components/BeanListPage";
+
+export const Route = createFileRoute("/beans/")({
+  component: BeanListPage,
+});

--- a/src/routes/beans.new.tsx
+++ b/src/routes/beans.new.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { BeanCreatePage } from "@/components/BeanCreatePage";
+
+export const Route = createFileRoute("/beans/new")({
+  component: BeanCreatePage,
+});

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { BeanListPage } from "@/components/BeanListPage";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({
-  component: BeanListPage,
+  beforeLoad: () => {
+    throw redirect({ to: "/beans" });
+  },
 });


### PR DESCRIPTION
## Summary
- Bean 詳細・編集・削除ページと全フィールドフォームを追加し、Slice 3（Bean CRUD）の受け入れ条件を完全に満たす
- TanStack Router で `/beans`, `/beans/new`, `/beans/$beanId`, `/beans/$beanId/edit` を追加。`/` から `/beans` へリダイレクト
- 純関数 `monthsSincePurchase` を `src/domain/bean.ts` に追加し、購入からの経過月数を詳細画面で表示

## Test plan
- [x] `npm run test:unit` — `src/domain/bean.test.ts` 5 pass（経過月数 / null / 不正値）
- [x] `npm run test:browser` — `BeanForm`, `BeanCreatePage`, `BeanDetailPage`, `BeanEditPage`, `BeanListPage`, `useBeans` 全 pass
- [x] `npm run test:coverage` — `src/domain/**` `src/schemas/**` 100% 維持
- [x] `npm run lint:fix` / `npx tsc -b --noEmit` / `npm run arch:check` 全 pass
- [x] `npm run build` 成功

## Acceptance criteria (Issue #4)
- [x] 豆一覧画面に登録済み Bean が一覧表示される（name, origin, stockG）
- [x] 豆作成フォームで全フィールドを入力して保存できる
- [x] 保存後に豆詳細画面へ遷移する
- [x] 豆詳細画面に全フィールドが表示される。`purchasedAt` からの経過月数も表示される
- [x] 豆を編集できる（在庫数値の手動変更を含む）
- [x] 豆を削除すると豆一覧へ遷移する
- [x] ブラウザリロード後もデータが保持される（IndexedDB / Dexie）
- [x] Bean リポジトリの CRUD テストがパスする（real IndexedDB / ADR-0001 方針）

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **豆の管理機能**
  * 豆の一覧表示、作成、詳細表示、編集、削除機能を追加しました
  * 原産地、購入日、在庫（g）などの豆の情報を管理できます
  * 購入日からの経過月数が自動計算されるようになりました
  * フォーム入力時の必須項目バリデーションに対応しました

## テスト

* すべてのページと機能に包括的なテストが追加されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->