### PR TITLE
feat: GitHub Pages デプロイ設定を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,10 @@
 import "./index.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createRouter, RouterProvider } from "@tanstack/react-router";
+import {
+  createHashHistory,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { db } from "./db";
@@ -8,7 +12,7 @@ import { seedMasterData } from "./repositories/seedMasterData";
 import { routeTree } from "./routeTree.gen";
 
 const queryClient = new QueryClient();
-const router = createRouter({ routeTree });
+const router = createRouter({ routeTree, history: createHashHistory() });
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from "vite";
 import checker from "vite-plugin-checker";
 
 export default defineConfig({
+  base: "/RoastLog/",
   plugins: [
     TanStackRouterVite(),
     tailwindcss(),


### PR DESCRIPTION
## Summary

- `vite.config.ts` に `base: "/RoastLog/"` を追加（GitHub Pages のサブパス対応）
- `main.tsx` をハッシュルーター (`createHashHistory`) に変更（直接URLアクセス時の404回避）
- `.github/workflows/deploy.yml` を追加（`main` ブランチへの push で自動デプロイ）

## 公開 URL

マージ後、GitHub Actions が完了すると以下で公開されます：  
https://otufor.github.io/RoastLog/

## Test plan

- [ ] ビルドが通ること（`npm run build`）— ローカルで確認済み
- [ ] PR マージ後に Actions が成功すること
- [ ] `https://otufor.github.io/RoastLog/` でアプリが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)