### PR TITLE
feat(slice-4): RoastLog CRUD コア（フォーム・一覧・詳細 + TimePicker + WeightLossRate）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "msw": "^2.14.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-mobile-picker": "^1.2.0",
         "shadcn": "^4.6.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.4",
@@ -7446,6 +7447,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-mobile-picker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-mobile-picker/-/react-mobile-picker-1.2.0.tgz",
+      "integrity": "sha512-utIgq/rqJfDw+qL3CA6j5e3JqlAoc1kHucJi2vNiwspjaa1XJurJN/FKWBSgui1wV0gzS0BYutd2CbwcyR2eDA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "msw": "^2.14.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-mobile-picker": "^1.2.0",
     "shadcn": "^4.6.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.4",

--- a/src/components/RoastLogCreatePage.test.tsx
+++ b/src/components/RoastLogCreatePage.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { RoastLogCreatePage } from "@/components/RoastLogCreatePage";
+import { db } from "@/db";
+import type { Bean } from "@/schemas/bean";
+import type { RoastLevel } from "@/schemas/masterData";
+
+const BEAN: Bean = {
+  id: "550e8400-e29b-41d4-a716-446655440001",
+  name: "エチオピア イルガチェフェ",
+  origin: "エチオピア",
+  productName: "",
+  shopName: "",
+  purchasedAt: null,
+  importedAt: null,
+  stockG: 500,
+  bestLogId: null,
+  note: "",
+};
+
+const LEVEL: RoastLevel = {
+  id: "medium",
+  label: "中煎り",
+  color: "#B06B1E",
+  order: 3,
+};
+
+const LOG_DETAIL_PATH = "/logs/$logId";
+
+function renderCreatePage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const createRoute_ = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/logs/new",
+    component: RoastLogCreatePage,
+  });
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: LOG_DETAIL_PATH,
+    component: () => <div>詳細ページ</div>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([createRoute_, detailRoute]),
+    history: createMemoryHistory({ initialEntries: ["/logs/new"] }),
+  });
+
+  render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+
+  return { router };
+}
+
+describe("RoastLogCreatePage", () => {
+  beforeEach(async () => {
+    await Promise.all([
+      db.roastLevels.clear(),
+      db.flavorTags.clear(),
+      db.roastDevices.clear(),
+      db.beans.clear(),
+      db.roastLogs.clear(),
+    ]);
+  });
+
+  it("フォームのタイトル「新しい焙煎を記録」を表示する", async () => {
+    renderCreatePage();
+    await waitFor(() =>
+      expect(screen.getByText("新しい焙煎を記録")).toBeInTheDocument(),
+    );
+  });
+
+  it("保存後に詳細ページへ遷移する", async () => {
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+
+    const { router } = renderCreatePage();
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("焙煎前重量 (g)")).toBeInTheDocument(),
+    );
+
+    const beforeInput = screen.getByLabelText("焙煎前重量 (g)");
+    const afterInput = screen.getByLabelText("焙煎後重量 (g)");
+    await userEvent.clear(beforeInput);
+    await userEvent.type(beforeInput, "250");
+    await userEvent.clear(afterInput);
+    await userEvent.type(afterInput, "210");
+
+    await userEvent.click(screen.getByRole("button", { name: "登録" }));
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toMatch(/^\/logs\/.+$/),
+    );
+    expect(screen.getByText("詳細ページ")).toBeInTheDocument();
+  });
+});

--- a/src/components/RoastLogCreatePage.tsx
+++ b/src/components/RoastLogCreatePage.tsx
@@ -6,12 +6,9 @@ import { useRoastDevices } from "@/hooks/useRoastDevices";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
 import type { CreateRoastLogInput } from "@/schemas/roastLog";
 
-const today = new Date();
-const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
-
 const EMPTY_DEFAULTS: CreateRoastLogInput = {
   beanId: "",
-  roastDate: todayStr,
+  roastDate: "",
   roastLevelId: "",
   roastDeviceId: null,
   roastDurationSec: 0,
@@ -38,8 +35,11 @@ export function RoastLogCreatePage() {
 
   if (beansLoading || levelsLoading || devicesLoading) return null;
 
+  const today = new Date();
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
   const defaultValues: CreateRoastLogInput = {
     ...EMPTY_DEFAULTS,
+    roastDate: todayStr,
     beanId: beans[0]?.id ?? "",
     roastLevelId: levels[0]?.id ?? "",
     roastDeviceId: devices[0]?.id ?? null,

--- a/src/components/RoastLogCreatePage.tsx
+++ b/src/components/RoastLogCreatePage.tsx
@@ -1,0 +1,64 @@
+import { useNavigate } from "@tanstack/react-router";
+import { RoastLogForm } from "@/components/RoastLogForm";
+import { useBeans } from "@/hooks/useBeans";
+import { useCreateRoastLog } from "@/hooks/useMutateRoastLog";
+import { useRoastDevices } from "@/hooks/useRoastDevices";
+import { useRoastLevels } from "@/hooks/useRoastLevels";
+import type { CreateRoastLogInput } from "@/schemas/roastLog";
+
+const today = new Date();
+const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+
+const EMPTY_DEFAULTS: CreateRoastLogInput = {
+  beanId: "",
+  roastDate: todayStr,
+  roastLevelId: "",
+  roastDeviceId: null,
+  roastDurationSec: 0,
+  firstCrackSec: null,
+  secondCrackSec: null,
+  weightBeforeG: 0,
+  weightAfterG: 0,
+  outdoorTempC: null,
+  outdoorHumidity: null,
+  indoorTempC: null,
+  tempSource: "manual",
+  weatherCode: null,
+  tasting: null,
+  overallScore: null,
+  processNote: "",
+};
+
+export function RoastLogCreatePage() {
+  const navigate = useNavigate();
+  const { mutateAsync } = useCreateRoastLog();
+  const { data: beans = [], isLoading: beansLoading } = useBeans();
+  const { data: levels = [], isLoading: levelsLoading } = useRoastLevels();
+  const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
+
+  if (beansLoading || levelsLoading || devicesLoading) return null;
+
+  const defaultValues: CreateRoastLogInput = {
+    ...EMPTY_DEFAULTS,
+    beanId: beans[0]?.id ?? "",
+    roastLevelId: levels[0]?.id ?? "",
+    roastDeviceId: devices[0]?.id ?? null,
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="mb-4 text-2xl font-bold">新しい焙煎を記録</h1>
+      <RoastLogForm
+        defaultValues={defaultValues}
+        beans={beans}
+        roastLevels={levels}
+        roastDevices={devices}
+        submitLabel="登録"
+        onSubmit={async (input: CreateRoastLogInput) => {
+          const log = await mutateAsync(input);
+          await navigate({ to: "/logs/$logId", params: { logId: log.id } });
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/RoastLogDetailPage.test.tsx
+++ b/src/components/RoastLogDetailPage.test.tsx
@@ -1,0 +1,177 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { RoastLogDetailPage } from "@/components/RoastLogDetailPage";
+import { db } from "@/db";
+import type { Bean } from "@/schemas/bean";
+import type { RoastDevice, RoastLevel } from "@/schemas/masterData";
+import type { RoastLog } from "@/schemas/roastLog";
+
+const BEAN: Bean = {
+  id: "550e8400-e29b-41d4-a716-446655440001",
+  name: "エチオピア イルガチェフェ",
+  origin: "エチオピア",
+  productName: "",
+  shopName: "",
+  purchasedAt: null,
+  importedAt: null,
+  stockG: 500,
+  bestLogId: null,
+  note: "",
+};
+
+const LEVEL: RoastLevel = {
+  id: "medium",
+  label: "中煎り",
+  color: "#B06B1E",
+  order: 3,
+};
+
+const DEVICE: RoastDevice = {
+  id: "device-1",
+  name: "手網",
+  method: "",
+  note: "",
+};
+
+const LOG: RoastLog = {
+  id: "550e8400-e29b-41d4-a716-446655440099",
+  beanId: BEAN.id,
+  roastDate: "2025-04-20",
+  roastLevelId: LEVEL.id,
+  roastDeviceId: DEVICE.id,
+  roastDurationSec: 480,
+  firstCrackSec: 300,
+  secondCrackSec: null,
+  weightBeforeG: 250,
+  weightAfterG: 210,
+  outdoorTempC: null,
+  outdoorHumidity: null,
+  indoorTempC: 22,
+  tempSource: "manual",
+  weatherCode: null,
+  tasting: null,
+  overallScore: null,
+  processNote: "テストメモ",
+};
+
+function renderDetailPage(logId: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/logs/$logId",
+    component: () => <RoastLogDetailPage logId={logId} />,
+  });
+  const editRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/logs/$logId/edit",
+    component: () => <div>編集ページ</div>,
+  });
+  const listRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/logs",
+    component: () => <div>一覧ページ</div>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([detailRoute, editRoute, listRoute]),
+    history: createMemoryHistory({ initialEntries: [`/logs/${logId}`] }),
+  });
+
+  render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+
+  return router;
+}
+
+describe("RoastLogDetailPage", () => {
+  beforeEach(async () => {
+    await Promise.all([
+      db.roastLevels.clear(),
+      db.flavorTags.clear(),
+      db.roastDevices.clear(),
+      db.beans.clear(),
+      db.roastLogs.clear(),
+    ]);
+  });
+
+  it("豆名・焙煎日・焙煎度・焙煎機・WeightLossRate を表示する", async () => {
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastDevices.put(DEVICE);
+    await db.roastLogs.put(LOG);
+
+    renderDetailPage(LOG.id);
+
+    await waitFor(() =>
+      expect(screen.getByText("エチオピア イルガチェフェ")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("2025-04-20")).toBeInTheDocument();
+    expect(screen.getByText("中煎り")).toBeInTheDocument();
+    expect(screen.getByText("手網")).toBeInTheDocument();
+    expect(screen.getByText(/16\.0%/)).toBeInTheDocument();
+  });
+
+  it("processNote を表示する", async () => {
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastDevices.put(DEVICE);
+    await db.roastLogs.put(LOG);
+
+    renderDetailPage(LOG.id);
+
+    await waitFor(() =>
+      expect(screen.getByText("テストメモ")).toBeInTheDocument(),
+    );
+  });
+
+  it("「編集」ボタンで編集ページへ遷移する", async () => {
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastDevices.put(DEVICE);
+    await db.roastLogs.put(LOG);
+
+    const router = renderDetailPage(LOG.id);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "編集" })).toBeInTheDocument(),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "編集" }));
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toMatch(/\/edit$/),
+    );
+    expect(screen.getByText("編集ページ")).toBeInTheDocument();
+  });
+
+  it("「削除」ボタンでログを削除し一覧へ遷移する", async () => {
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastDevices.put(DEVICE);
+    await db.roastLogs.put(LOG);
+
+    const router = renderDetailPage(LOG.id);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "削除" })).toBeInTheDocument(),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/logs"));
+    expect(screen.getByText("一覧ページ")).toBeInTheDocument();
+  });
+});

--- a/src/components/RoastLogDetailPage.tsx
+++ b/src/components/RoastLogDetailPage.tsx
@@ -1,0 +1,108 @@
+import { useNavigate } from "@tanstack/react-router";
+import { calcWeightLossRate } from "@/domain/roastLog";
+import { useBeans } from "@/hooks/useBeans";
+import { useDeleteRoastLog } from "@/hooks/useMutateRoastLog";
+import { useRoastDevices } from "@/hooks/useRoastDevices";
+import { useRoastLevels } from "@/hooks/useRoastLevels";
+import { useRoastLog } from "@/hooks/useRoastLogs";
+
+function formatSec(sec: number | null): string {
+  if (sec === null) return "—";
+  const mm = String(Math.floor(sec / 60)).padStart(2, "0");
+  const ss = String(sec % 60).padStart(2, "0");
+  return `${mm}:${ss}`;
+}
+
+interface RoastLogDetailPageProps {
+  logId: string;
+}
+
+export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
+  const navigate = useNavigate();
+  const { data: log, isLoading: logLoading } = useRoastLog(logId);
+  const { data: beans = [], isLoading: beansLoading } = useBeans();
+  const { data: levels = [], isLoading: levelsLoading } = useRoastLevels();
+  const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
+  const { mutateAsync: deleteLog } = useDeleteRoastLog();
+
+  if (logLoading || beansLoading || levelsLoading || devicesLoading)
+    return null;
+  if (!log) return <p>ログが見つかりません</p>;
+
+  const bean = beans.find((b) => b.id === log.beanId);
+  const level = levels.find((l) => l.id === log.roastLevelId);
+  const device = devices.find((d) => d.id === log.roastDeviceId);
+  const rate = calcWeightLossRate(log.weightBeforeG, log.weightAfterG);
+
+  const handleDelete = async () => {
+    await deleteLog(logId);
+    await navigate({ to: "/logs" });
+  };
+
+  const handleEdit = async () => {
+    await navigate({ to: "/logs/$logId/edit", params: { logId } });
+  };
+
+  return (
+    <div className="p-6 flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{bean?.name ?? "—"}</h1>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={handleEdit}
+            className="px-4 py-2 rounded-lg border border-border text-sm font-medium"
+          >
+            編集
+          </button>
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="px-4 py-2 rounded-lg bg-destructive text-destructive-foreground text-sm font-medium"
+          >
+            削除
+          </button>
+        </div>
+      </div>
+
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+        <dt className="text-muted-foreground">焙煎日</dt>
+        <dd>{log.roastDate}</dd>
+
+        <dt className="text-muted-foreground">焙煎度</dt>
+        <dd>{level?.label ?? "—"}</dd>
+
+        <dt className="text-muted-foreground">焙煎機</dt>
+        <dd>{device?.name ?? "—"}</dd>
+
+        <dt className="text-muted-foreground">焙煎時間</dt>
+        <dd>{formatSec(log.roastDurationSec)}</dd>
+
+        <dt className="text-muted-foreground">1ハゼ</dt>
+        <dd>{formatSec(log.firstCrackSec)}</dd>
+
+        <dt className="text-muted-foreground">2ハゼ</dt>
+        <dd>{formatSec(log.secondCrackSec)}</dd>
+
+        <dt className="text-muted-foreground">焙煎前重量</dt>
+        <dd>{log.weightBeforeG}g</dd>
+
+        <dt className="text-muted-foreground">焙煎後重量</dt>
+        <dd>{log.weightAfterG}g</dd>
+
+        <dt className="text-muted-foreground">重量減少率</dt>
+        <dd>{rate.toFixed(1)}%</dd>
+
+        <dt className="text-muted-foreground">室内温度</dt>
+        <dd>{log.indoorTempC != null ? `${log.indoorTempC}℃` : "—"}</dd>
+      </dl>
+
+      {log.processNote && (
+        <div>
+          <p className="text-sm text-muted-foreground mb-1">焙煎メモ</p>
+          <p className="text-sm">{log.processNote}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/RoastLogEditPage.test.tsx
+++ b/src/components/RoastLogEditPage.test.tsx
@@ -1,0 +1,133 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { RoastLogEditPage } from "@/components/RoastLogEditPage";
+import { db } from "@/db";
+import type { Bean } from "@/schemas/bean";
+import type { RoastLevel } from "@/schemas/masterData";
+import type { RoastLog } from "@/schemas/roastLog";
+
+const BEAN: Bean = {
+  id: "550e8400-e29b-41d4-a716-446655440001",
+  name: "エチオピア イルガチェフェ",
+  origin: "エチオピア",
+  productName: "",
+  shopName: "",
+  purchasedAt: null,
+  importedAt: null,
+  stockG: 500,
+  bestLogId: null,
+  note: "",
+};
+
+const LEVEL: RoastLevel = {
+  id: "medium",
+  label: "中煎り",
+  color: "#B06B1E",
+  order: 3,
+};
+
+const LOG: RoastLog = {
+  id: "550e8400-e29b-41d4-a716-446655440099",
+  beanId: BEAN.id,
+  roastDate: "2025-04-20",
+  roastLevelId: LEVEL.id,
+  roastDeviceId: null,
+  roastDurationSec: 480,
+  firstCrackSec: 300,
+  secondCrackSec: null,
+  weightBeforeG: 250,
+  weightAfterG: 210,
+  outdoorTempC: null,
+  outdoorHumidity: null,
+  indoorTempC: null,
+  tempSource: "manual",
+  weatherCode: null,
+  tasting: null,
+  overallScore: null,
+  processNote: "",
+};
+
+function renderEditPage(logId: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const editRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/logs/$logId/edit",
+    component: () => <RoastLogEditPage logId={logId} />,
+  });
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/logs/$logId",
+    component: () => <div>詳細ページ</div>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([editRoute, detailRoute]),
+    history: createMemoryHistory({ initialEntries: [`/logs/${logId}/edit`] }),
+  });
+
+  render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+
+  return router;
+}
+
+describe("RoastLogEditPage", () => {
+  beforeEach(async () => {
+    await Promise.all([
+      db.roastLevels.clear(),
+      db.flavorTags.clear(),
+      db.roastDevices.clear(),
+      db.beans.clear(),
+      db.roastLogs.clear(),
+    ]);
+  });
+
+  it("既存の weightBeforeG を初期値として表示する", async () => {
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastLogs.put(LOG);
+
+    renderEditPage(LOG.id);
+
+    await waitFor(() => {
+      const input = screen.getByLabelText<HTMLInputElement>("焙煎前重量 (g)");
+      expect(input.value).toBe("250");
+    });
+  });
+
+  it("編集保存後に詳細ページへ遷移し、在庫は変動しない", async () => {
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastLogs.put(LOG);
+
+    const router = renderEditPage(LOG.id);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("焙煎前重量 (g)")).toBeInTheDocument(),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("詳細ページ")).toBeInTheDocument(),
+    );
+
+    expect(router.state.location.pathname).not.toMatch(/\/edit$/);
+
+    const bean = await db.beans.get(BEAN.id);
+    expect(bean?.stockG).toBe(500);
+  });
+});

--- a/src/components/RoastLogEditPage.tsx
+++ b/src/components/RoastLogEditPage.tsx
@@ -1,0 +1,62 @@
+import { useNavigate } from "@tanstack/react-router";
+import { RoastLogForm } from "@/components/RoastLogForm";
+import { useBeans } from "@/hooks/useBeans";
+import { useUpdateRoastLog } from "@/hooks/useMutateRoastLog";
+import { useRoastDevices } from "@/hooks/useRoastDevices";
+import { useRoastLevels } from "@/hooks/useRoastLevels";
+import { useRoastLog } from "@/hooks/useRoastLogs";
+import type { CreateRoastLogInput } from "@/schemas/roastLog";
+
+interface RoastLogEditPageProps {
+  logId: string;
+}
+
+export function RoastLogEditPage({ logId }: RoastLogEditPageProps) {
+  const navigate = useNavigate();
+  const { data: log, isLoading: logLoading } = useRoastLog(logId);
+  const { data: beans = [], isLoading: beansLoading } = useBeans();
+  const { data: levels = [], isLoading: levelsLoading } = useRoastLevels();
+  const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
+  const { mutateAsync: updateLog } = useUpdateRoastLog();
+
+  if (logLoading || beansLoading || levelsLoading || devicesLoading)
+    return null;
+  if (!log) return <p>ログが見つかりません</p>;
+
+  const defaultValues: CreateRoastLogInput = {
+    beanId: log.beanId,
+    roastDate: log.roastDate,
+    roastLevelId: log.roastLevelId,
+    roastDeviceId: log.roastDeviceId,
+    roastDurationSec: log.roastDurationSec,
+    firstCrackSec: log.firstCrackSec,
+    secondCrackSec: log.secondCrackSec,
+    weightBeforeG: log.weightBeforeG,
+    weightAfterG: log.weightAfterG,
+    outdoorTempC: log.outdoorTempC,
+    outdoorHumidity: log.outdoorHumidity,
+    indoorTempC: log.indoorTempC,
+    tempSource: log.tempSource,
+    weatherCode: log.weatherCode,
+    tasting: log.tasting,
+    overallScore: log.overallScore,
+    processNote: log.processNote,
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="mb-4 text-2xl font-bold">焙煎ログを編集</h1>
+      <RoastLogForm
+        defaultValues={defaultValues}
+        beans={beans}
+        roastLevels={levels}
+        roastDevices={devices}
+        submitLabel="保存"
+        onSubmit={async (input: CreateRoastLogInput) => {
+          await updateLog({ ...log, ...input });
+          await navigate({ to: "/logs/$logId", params: { logId } });
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/RoastLogForm.test.tsx
+++ b/src/components/RoastLogForm.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, waitFor } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { RoastLogForm } from "@/components/RoastLogForm";
+import type { Bean } from "@/schemas/bean";
+import type { RoastDevice, RoastLevel } from "@/schemas/masterData";
+import type { CreateRoastLogInput } from "@/schemas/roastLog";
+
+const BEAN: Bean = {
+  id: "550e8400-e29b-41d4-a716-446655440001",
+  name: "エチオピア イルガチェフェ",
+  origin: "エチオピア",
+  productName: "",
+  shopName: "",
+  purchasedAt: null,
+  importedAt: null,
+  stockG: 500,
+  bestLogId: null,
+  note: "",
+};
+
+const LEVEL: RoastLevel = {
+  id: "medium",
+  label: "中煎り",
+  color: "#B06B1E",
+  order: 3,
+};
+
+const DEVICE: RoastDevice = {
+  id: "device-1",
+  name: "手網",
+  method: "",
+  note: "",
+};
+
+const DEFAULTS: CreateRoastLogInput = {
+  beanId: BEAN.id,
+  roastDate: "2025-04-20",
+  roastLevelId: LEVEL.id,
+  roastDeviceId: null,
+  roastDurationSec: 480,
+  firstCrackSec: 300,
+  secondCrackSec: null,
+  weightBeforeG: 250,
+  weightAfterG: 210,
+  outdoorTempC: null,
+  outdoorHumidity: null,
+  indoorTempC: null,
+  tempSource: "manual",
+  weatherCode: null,
+  tasting: null,
+  overallScore: null,
+  processNote: "",
+};
+
+function renderForm(
+  overrides: Partial<CreateRoastLogInput> = {},
+  onSubmit = vi.fn(),
+) {
+  render(
+    <RoastLogForm
+      defaultValues={{ ...DEFAULTS, ...overrides }}
+      beans={[BEAN]}
+      roastLevels={[LEVEL]}
+      roastDevices={[DEVICE]}
+      submitLabel="登録"
+      onSubmit={onSubmit}
+    />,
+  );
+}
+
+describe("RoastLogForm", () => {
+  it("WeightLossRate を初期値から計算して表示する (250g→210g = 16.0%)", () => {
+    renderForm();
+    expect(screen.getByText(/16\.0%/)).toBeInTheDocument();
+  });
+
+  it("weightAfterG を変更すると WeightLossRate がリアルタイム更新される", async () => {
+    renderForm();
+    const input = screen.getByLabelText("焙煎後重量 (g)");
+    await userEvent.clear(input);
+    await userEvent.type(input, "200");
+    await waitFor(() => expect(screen.getByText(/20\.0%/)).toBeInTheDocument());
+  });
+
+  it("有効なデータで送信すると onSubmit が呼ばれる", async () => {
+    const onSubmit = vi.fn();
+    renderForm({}, onSubmit);
+    await userEvent.click(screen.getByRole("button", { name: "登録" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ beanId: BEAN.id, weightBeforeG: 250 }),
+    );
+  });
+
+  it("weightBeforeG が 0 のとき送信エラーを表示する", async () => {
+    renderForm({ weightBeforeG: 0 });
+    await userEvent.click(screen.getByRole("button", { name: "登録" }));
+    await waitFor(() =>
+      expect(screen.getByText(/焙煎前重量は0より大きい/)).toBeInTheDocument(),
+    );
+  });
+});

--- a/src/components/RoastLogForm.tsx
+++ b/src/components/RoastLogForm.tsx
@@ -194,8 +194,8 @@ export function RoastLogForm({
           <div className="flex flex-col gap-1">
             <Label htmlFor="log-roast-device-id">焙煎機</Label>
             <Select
-              value={field.state.value}
-              onValueChange={(v) => field.handleChange(v ?? null)}
+              value={field.state.value ?? undefined}
+              onValueChange={(v) => field.handleChange(v === "" ? null : v)}
             >
               <SelectTrigger id="log-roast-device-id" className="w-full">
                 <SelectValue placeholder="なし" />

--- a/src/components/RoastLogForm.tsx
+++ b/src/components/RoastLogForm.tsx
@@ -1,0 +1,357 @@
+import { useForm, useStore } from "@tanstack/react-form";
+import { z } from "zod";
+import { TimePicker } from "@/components/TimePicker";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { calcWeightLossRate } from "@/domain/roastLog";
+import type { Bean } from "@/schemas/bean";
+import type { RoastDevice, RoastLevel } from "@/schemas/masterData";
+import type { CreateRoastLogInput } from "@/schemas/roastLog";
+
+const FormSchema = z.object({
+  beanId: z.string().min(1, "豆を選択してください"),
+  roastDate: z.string().min(1, "焙煎日を入力してください"),
+  roastLevelId: z.string().min(1, "焙煎度を選択してください"),
+  roastDeviceId: z.string().nullable(),
+  roastDurationSec: z.number().int().nonnegative(),
+  firstCrackSec: z.number().int().nonnegative().nullable(),
+  secondCrackSec: z.number().int().nonnegative().nullable(),
+  weightBeforeG: z
+    .number()
+    .positive("焙煎前重量は0より大きい値を入力してください"),
+  weightAfterG: z
+    .number()
+    .positive("焙煎後重量は0より大きい値を入力してください"),
+  indoorTempC: z.number().nullable(),
+  processNote: z.string(),
+});
+
+interface RoastLogFormProps {
+  defaultValues: CreateRoastLogInput;
+  beans: Bean[];
+  roastLevels: RoastLevel[];
+  roastDevices: RoastDevice[];
+  submitLabel: string;
+  onSubmit: (input: CreateRoastLogInput) => void | Promise<void>;
+}
+
+export function RoastLogForm({
+  defaultValues,
+  beans,
+  roastLevels,
+  roastDevices,
+  submitLabel,
+  onSubmit,
+}: RoastLogFormProps) {
+  const form = useForm({
+    defaultValues: {
+      beanId: defaultValues.beanId,
+      roastDate: defaultValues.roastDate,
+      roastLevelId: defaultValues.roastLevelId,
+      roastDeviceId: defaultValues.roastDeviceId,
+      roastDurationSec: defaultValues.roastDurationSec,
+      firstCrackSec: defaultValues.firstCrackSec,
+      secondCrackSec: defaultValues.secondCrackSec,
+      weightBeforeG: defaultValues.weightBeforeG,
+      weightAfterG: defaultValues.weightAfterG,
+      indoorTempC: defaultValues.indoorTempC,
+      processNote: defaultValues.processNote,
+    },
+    validators: { onSubmit: FormSchema },
+    onSubmit: async ({ value }) => {
+      await onSubmit({
+        ...defaultValues,
+        ...value,
+      });
+    },
+  });
+
+  const weightLossRate = useStore(form.store, (state) =>
+    calcWeightLossRate(state.values.weightBeforeG, state.values.weightAfterG),
+  );
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="flex flex-col gap-4"
+    >
+      {/* 豆 */}
+      <form.Field name="beanId">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="log-bean-id">豆</Label>
+            <Select
+              value={field.state.value || null}
+              onValueChange={(v) => field.handleChange(v ?? "")}
+            >
+              <SelectTrigger id="log-bean-id" className="w-full">
+                <SelectValue placeholder="豆を選択" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {beans.map((b) => (
+                    <SelectItem key={b.id} value={b.id}>
+                      {b.name}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            {field.state.meta.errors.map((err) =>
+              err ? (
+                <span
+                  key={err.message ?? String(err)}
+                  role="alert"
+                  className="text-sm text-destructive"
+                >
+                  {err.message ?? String(err)}
+                </span>
+              ) : null,
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      {/* 焙煎日 */}
+      <form.Field name="roastDate">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="log-roast-date">焙煎日</Label>
+            <Input
+              id="log-roast-date"
+              type="date"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+            {field.state.meta.errors.map((err) =>
+              err ? (
+                <span
+                  key={err.message ?? String(err)}
+                  role="alert"
+                  className="text-sm text-destructive"
+                >
+                  {err.message ?? String(err)}
+                </span>
+              ) : null,
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      {/* 焙煎度 */}
+      <form.Field name="roastLevelId">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="log-roast-level-id">焙煎度</Label>
+            <Select
+              value={field.state.value || null}
+              onValueChange={(v) => field.handleChange(v ?? "")}
+            >
+              <SelectTrigger id="log-roast-level-id" className="w-full">
+                <SelectValue placeholder="焙煎度を選択" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {roastLevels.map((l) => (
+                    <SelectItem key={l.id} value={l.id}>
+                      {l.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            {field.state.meta.errors.map((err) =>
+              err ? (
+                <span
+                  key={err.message ?? String(err)}
+                  role="alert"
+                  className="text-sm text-destructive"
+                >
+                  {err.message ?? String(err)}
+                </span>
+              ) : null,
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      {/* 焙煎機 */}
+      <form.Field name="roastDeviceId">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="log-roast-device-id">焙煎機</Label>
+            <Select
+              value={field.state.value}
+              onValueChange={(v) => field.handleChange(v ?? null)}
+            >
+              <SelectTrigger id="log-roast-device-id" className="w-full">
+                <SelectValue placeholder="なし" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value="">なし</SelectItem>
+                  {roastDevices.map((d) => (
+                    <SelectItem key={d.id} value={d.id}>
+                      {d.name}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      </form.Field>
+
+      {/* 焙煎時間 */}
+      <form.Field name="roastDurationSec">
+        {(field) => (
+          <TimePicker
+            label="焙煎時間"
+            value={field.state.value}
+            onChange={(v) => field.handleChange(v ?? 0)}
+          />
+        )}
+      </form.Field>
+
+      {/* 1ハゼ */}
+      <form.Field name="firstCrackSec">
+        {(field) => (
+          <TimePicker
+            label="1ハゼ"
+            value={field.state.value}
+            onChange={(v) => field.handleChange(v)}
+            nullable
+          />
+        )}
+      </form.Field>
+
+      {/* 2ハゼ */}
+      <form.Field name="secondCrackSec">
+        {(field) => (
+          <TimePicker
+            label="2ハゼ"
+            value={field.state.value}
+            onChange={(v) => field.handleChange(v)}
+            nullable
+          />
+        )}
+      </form.Field>
+
+      {/* 重量 + WeightLossRate */}
+      <div className="flex flex-col gap-3">
+        <div className="flex gap-3">
+          <form.Field name="weightBeforeG">
+            {(field) => (
+              <div className="flex flex-1 flex-col gap-1">
+                <Label htmlFor="log-weight-before">焙煎前重量 (g)</Label>
+                <Input
+                  id="log-weight-before"
+                  type="number"
+                  min={0}
+                  step={0.1}
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(Number(e.target.value))}
+                />
+                {field.state.meta.errors.map((err) =>
+                  err ? (
+                    <span
+                      key={err.message ?? String(err)}
+                      role="alert"
+                      className="text-sm text-destructive"
+                    >
+                      {err.message ?? String(err)}
+                    </span>
+                  ) : null,
+                )}
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="weightAfterG">
+            {(field) => (
+              <div className="flex flex-1 flex-col gap-1">
+                <Label htmlFor="log-weight-after">焙煎後重量 (g)</Label>
+                <Input
+                  id="log-weight-after"
+                  type="number"
+                  min={0}
+                  step={0.1}
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(Number(e.target.value))}
+                />
+                {field.state.meta.errors.map((err) =>
+                  err ? (
+                    <span
+                      key={err.message ?? String(err)}
+                      role="alert"
+                      className="text-sm text-destructive"
+                    >
+                      {err.message ?? String(err)}
+                    </span>
+                  ) : null,
+                )}
+              </div>
+            )}
+          </form.Field>
+        </div>
+
+        <div className="flex items-center justify-between rounded-md bg-muted px-3 py-2">
+          <span className="text-sm text-muted-foreground">重量減少率</span>
+          <span className="font-mono text-sm font-medium">
+            {weightLossRate.toFixed(1)}%
+          </span>
+        </div>
+      </div>
+
+      {/* 室内温度 */}
+      <form.Field name="indoorTempC">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="log-indoor-temp">室内温度 (℃)</Label>
+            <Input
+              id="log-indoor-temp"
+              type="number"
+              step={0.1}
+              value={field.state.value ?? ""}
+              onChange={(e) =>
+                field.handleChange(
+                  e.target.value === "" ? null : Number(e.target.value),
+                )
+              }
+            />
+          </div>
+        )}
+      </form.Field>
+
+      {/* メモ */}
+      <form.Field name="processNote">
+        {(field) => (
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="log-process-note">焙煎メモ</Label>
+            <Textarea
+              id="log-process-note"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+              rows={3}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      <Button type="submit">{submitLabel}</Button>
+    </form>
+  );
+}

--- a/src/components/RoastLogListPage.tsx
+++ b/src/components/RoastLogListPage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { RoastBadge } from "@/components/RoastBadge";
 import { StarRating } from "@/components/StarRating";
@@ -15,6 +16,7 @@ const FILTERS = [
 ] as const;
 
 export function RoastLogListPage() {
+  const navigate = useNavigate();
   const [filter, setFilter] = useState<string>("all");
   const { data: logs = [], isLoading: logsLoading } = useRoastLogs();
   const { data: beans = [], isLoading: beansLoading } = useBeans();
@@ -195,8 +197,12 @@ export function RoastLogListPage() {
             );
 
             return (
-              <div
+              <button
+                type="button"
                 key={log.id}
+                onClick={() =>
+                  navigate({ to: "/logs/$logId", params: { logId: log.id } })
+                }
                 style={{
                   background: "var(--card)",
                   border: isDanger
@@ -206,6 +212,9 @@ export function RoastLogListPage() {
                   padding: 12,
                   boxShadow:
                     "0 1px 2px rgba(28,23,20,0.04), 0 1px 1px rgba(28,23,20,0.03)",
+                  cursor: "pointer",
+                  textAlign: "left",
+                  width: "100%",
                 }}
               >
                 <div
@@ -281,7 +290,7 @@ export function RoastLogListPage() {
                     </span>
                   )}
                 </div>
-              </div>
+              </button>
             );
           })
         )}
@@ -300,9 +309,9 @@ export function RoastLogListPage() {
           pointerEvents: "none",
         }}
       >
-        {/* TODO: add onClick to navigate to /logs/new once that route is created */}
         <button
           type="button"
+          onClick={() => navigate({ to: "/logs/new" })}
           style={{
             pointerEvents: "auto",
             width: "100%",

--- a/src/components/TimePicker.test.tsx
+++ b/src/components/TimePicker.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { TimePicker } from "@/components/TimePicker";
+
+describe("TimePicker", () => {
+  it("ラベルを表示する", () => {
+    render(<TimePicker label="焙煎時間" value={0} onChange={vi.fn()} />);
+    expect(screen.getByText("焙煎時間")).toBeInTheDocument();
+  });
+
+  it("value=300 のとき '05:00' と表示する", () => {
+    render(<TimePicker label="焙煎時間" value={300} onChange={vi.fn()} />);
+    expect(screen.getByText("05:00")).toBeInTheDocument();
+  });
+
+  it("value=185 のとき '03:05' と表示する", () => {
+    render(<TimePicker label="焙煎時間" value={185} onChange={vi.fn()} />);
+    expect(screen.getByText("03:05")).toBeInTheDocument();
+  });
+
+  it("nullable=true かつ value=null のとき「なし」トグルがオン", () => {
+    render(
+      <TimePicker label="1ハゼ" value={null} onChange={vi.fn()} nullable />,
+    );
+    const toggle = screen.getByRole("checkbox", { name: "なし" });
+    expect(toggle).toBeChecked();
+  });
+
+  it("nullable=true で「なし」をクリックすると onChange(null) が呼ばれる", async () => {
+    const onChange = vi.fn();
+    render(
+      <TimePicker label="1ハゼ" value={180} onChange={onChange} nullable />,
+    );
+    const toggle = screen.getByRole("checkbox", { name: "なし" });
+    await userEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("nullable=true かつ value=null のとき「なし」を外すと onChange(0) が呼ばれる", async () => {
+    const onChange = vi.fn();
+    render(
+      <TimePicker label="1ハゼ" value={null} onChange={onChange} nullable />,
+    );
+    const toggle = screen.getByRole("checkbox", { name: "なし" });
+    await userEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -1,0 +1,83 @@
+import Picker from "react-mobile-picker";
+import { Label } from "@/components/ui/label";
+
+const MINUTES = Array.from({ length: 60 }, (_, i) =>
+  String(i).padStart(2, "0"),
+);
+const SECONDS = Array.from({ length: 60 }, (_, i) =>
+  String(i).padStart(2, "0"),
+);
+
+function toPickerValue(seconds: number): { mm: string; ss: string } {
+  return {
+    mm: String(Math.floor(seconds / 60)).padStart(2, "0"),
+    ss: String(seconds % 60).padStart(2, "0"),
+  };
+}
+
+interface TimePickerProps {
+  label: string;
+  value: number | null;
+  onChange: (seconds: number | null) => void;
+  nullable?: boolean;
+}
+
+export function TimePicker({
+  label,
+  value,
+  onChange,
+  nullable = false,
+}: TimePickerProps) {
+  const isNull = value === null;
+  const pickerValue = toPickerValue(value ?? 0);
+  const displayText = `${pickerValue.mm}:${pickerValue.ss}`;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <Label>{label}</Label>
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-sm text-muted-foreground">
+            {displayText}
+          </span>
+          {nullable && (
+            <label className="flex items-center gap-1 text-sm cursor-pointer">
+              <input
+                type="checkbox"
+                aria-label="なし"
+                checked={isNull}
+                onChange={() => onChange(isNull ? 0 : null)}
+                className="size-4"
+              />
+              なし
+            </label>
+          )}
+        </div>
+      </div>
+      {!isNull && (
+        <Picker
+          value={pickerValue}
+          onChange={({ mm, ss }) => onChange(parseInt(mm) * 60 + parseInt(ss))}
+          wheelMode="natural"
+          height={120}
+          itemHeight={40}
+        >
+          <Picker.Column name="mm">
+            {MINUTES.map((m) => (
+              <Picker.Item key={m} value={m}>
+                {m}
+              </Picker.Item>
+            ))}
+          </Picker.Column>
+          <Picker.Column name="ss">
+            {SECONDS.map((s) => (
+              <Picker.Item key={s} value={s}>
+                {s}
+              </Picker.Item>
+            ))}
+          </Picker.Column>
+        </Picker>
+      )}
+    </div>
+  );
+}

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -57,7 +57,9 @@ export function TimePicker({
       {!isNull && (
         <Picker
           value={pickerValue}
-          onChange={({ mm, ss }) => onChange(parseInt(mm) * 60 + parseInt(ss))}
+          onChange={({ mm, ss }) =>
+            onChange(parseInt(mm, 10) * 60 + parseInt(ss, 10))
+          }
           wheelMode="natural"
           height={120}
           itemHeight={40}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -157,7 +157,7 @@ function SelectScrollUpButton({
     <SelectPrimitive.ScrollUpArrow
       data-slot="select-scroll-up-button"
       className={cn(
-        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        "sticky top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -175,7 +175,7 @@ function SelectScrollDownButton({
     <SelectPrimitive.ScrollDownArrow
       data-slot="select-scroll-down-button"
       className={cn(
-        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        "sticky bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,199 @@
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn(
+            "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon />
+    </SelectPrimitive.ScrollUpArrow>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon />
+    </SelectPrimitive.ScrollDownArrow>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,8 +14,11 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as LogsIndexRouteImport } from './routes/logs.index'
 import { Route as BeansIndexRouteImport } from './routes/beans.index'
 import { Route as AnalysisIndexRouteImport } from './routes/analysis.index'
+import { Route as LogsNewRouteImport } from './routes/logs.new'
 import { Route as BeansNewRouteImport } from './routes/beans.new'
+import { Route as LogsLogIdIndexRouteImport } from './routes/logs.$logId.index'
 import { Route as BeansBeanIdIndexRouteImport } from './routes/beans.$beanId.index'
+import { Route as LogsLogIdEditRouteImport } from './routes/logs.$logId.edit'
 import { Route as BeansBeanIdEditRouteImport } from './routes/beans.$beanId.edit'
 
 const SettingsRoute = SettingsRouteImport.update({
@@ -43,14 +46,29 @@ const AnalysisIndexRoute = AnalysisIndexRouteImport.update({
   path: '/analysis/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LogsNewRoute = LogsNewRouteImport.update({
+  id: '/logs/new',
+  path: '/logs/new',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BeansNewRoute = BeansNewRouteImport.update({
   id: '/beans/new',
   path: '/beans/new',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LogsLogIdIndexRoute = LogsLogIdIndexRouteImport.update({
+  id: '/logs/$logId/',
+  path: '/logs/$logId/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BeansBeanIdIndexRoute = BeansBeanIdIndexRouteImport.update({
   id: '/beans/$beanId/',
   path: '/beans/$beanId/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LogsLogIdEditRoute = LogsLogIdEditRouteImport.update({
+  id: '/logs/$logId/edit',
+  path: '/logs/$logId/edit',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BeansBeanIdEditRoute = BeansBeanIdEditRouteImport.update({
@@ -63,32 +81,41 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/settings': typeof SettingsRoute
   '/beans/new': typeof BeansNewRoute
+  '/logs/new': typeof LogsNewRoute
   '/analysis/': typeof AnalysisIndexRoute
   '/beans/': typeof BeansIndexRoute
   '/logs/': typeof LogsIndexRoute
   '/beans/$beanId/edit': typeof BeansBeanIdEditRoute
+  '/logs/$logId/edit': typeof LogsLogIdEditRoute
   '/beans/$beanId/': typeof BeansBeanIdIndexRoute
+  '/logs/$logId/': typeof LogsLogIdIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/settings': typeof SettingsRoute
   '/beans/new': typeof BeansNewRoute
+  '/logs/new': typeof LogsNewRoute
   '/analysis': typeof AnalysisIndexRoute
   '/beans': typeof BeansIndexRoute
   '/logs': typeof LogsIndexRoute
   '/beans/$beanId/edit': typeof BeansBeanIdEditRoute
+  '/logs/$logId/edit': typeof LogsLogIdEditRoute
   '/beans/$beanId': typeof BeansBeanIdIndexRoute
+  '/logs/$logId': typeof LogsLogIdIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/settings': typeof SettingsRoute
   '/beans/new': typeof BeansNewRoute
+  '/logs/new': typeof LogsNewRoute
   '/analysis/': typeof AnalysisIndexRoute
   '/beans/': typeof BeansIndexRoute
   '/logs/': typeof LogsIndexRoute
   '/beans/$beanId/edit': typeof BeansBeanIdEditRoute
+  '/logs/$logId/edit': typeof LogsLogIdEditRoute
   '/beans/$beanId/': typeof BeansBeanIdIndexRoute
+  '/logs/$logId/': typeof LogsLogIdIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -96,42 +123,54 @@ export interface FileRouteTypes {
     | '/'
     | '/settings'
     | '/beans/new'
+    | '/logs/new'
     | '/analysis/'
     | '/beans/'
     | '/logs/'
     | '/beans/$beanId/edit'
+    | '/logs/$logId/edit'
     | '/beans/$beanId/'
+    | '/logs/$logId/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/settings'
     | '/beans/new'
+    | '/logs/new'
     | '/analysis'
     | '/beans'
     | '/logs'
     | '/beans/$beanId/edit'
+    | '/logs/$logId/edit'
     | '/beans/$beanId'
+    | '/logs/$logId'
   id:
     | '__root__'
     | '/'
     | '/settings'
     | '/beans/new'
+    | '/logs/new'
     | '/analysis/'
     | '/beans/'
     | '/logs/'
     | '/beans/$beanId/edit'
+    | '/logs/$logId/edit'
     | '/beans/$beanId/'
+    | '/logs/$logId/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SettingsRoute: typeof SettingsRoute
   BeansNewRoute: typeof BeansNewRoute
+  LogsNewRoute: typeof LogsNewRoute
   AnalysisIndexRoute: typeof AnalysisIndexRoute
   BeansIndexRoute: typeof BeansIndexRoute
   LogsIndexRoute: typeof LogsIndexRoute
   BeansBeanIdEditRoute: typeof BeansBeanIdEditRoute
+  LogsLogIdEditRoute: typeof LogsLogIdEditRoute
   BeansBeanIdIndexRoute: typeof BeansBeanIdIndexRoute
+  LogsLogIdIndexRoute: typeof LogsLogIdIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -171,6 +210,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AnalysisIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/logs/new': {
+      id: '/logs/new'
+      path: '/logs/new'
+      fullPath: '/logs/new'
+      preLoaderRoute: typeof LogsNewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/beans/new': {
       id: '/beans/new'
       path: '/beans/new'
@@ -178,11 +224,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BeansNewRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/logs/$logId/': {
+      id: '/logs/$logId/'
+      path: '/logs/$logId'
+      fullPath: '/logs/$logId/'
+      preLoaderRoute: typeof LogsLogIdIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/beans/$beanId/': {
       id: '/beans/$beanId/'
       path: '/beans/$beanId'
       fullPath: '/beans/$beanId/'
       preLoaderRoute: typeof BeansBeanIdIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/logs/$logId/edit': {
+      id: '/logs/$logId/edit'
+      path: '/logs/$logId/edit'
+      fullPath: '/logs/$logId/edit'
+      preLoaderRoute: typeof LogsLogIdEditRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/beans/$beanId/edit': {
@@ -199,11 +259,14 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SettingsRoute: SettingsRoute,
   BeansNewRoute: BeansNewRoute,
+  LogsNewRoute: LogsNewRoute,
   AnalysisIndexRoute: AnalysisIndexRoute,
   BeansIndexRoute: BeansIndexRoute,
   LogsIndexRoute: LogsIndexRoute,
   BeansBeanIdEditRoute: BeansBeanIdEditRoute,
+  LogsLogIdEditRoute: LogsLogIdEditRoute,
   BeansBeanIdIndexRoute: BeansBeanIdIndexRoute,
+  LogsLogIdIndexRoute: LogsLogIdIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/logs.$logId.edit.tsx
+++ b/src/routes/logs.$logId.edit.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { RoastLogEditPage } from "@/components/RoastLogEditPage";
+
+export const Route = createFileRoute("/logs/$logId/edit")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { logId } = Route.useParams();
+  return <RoastLogEditPage logId={logId} />;
+}

--- a/src/routes/logs.$logId.index.tsx
+++ b/src/routes/logs.$logId.index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { RoastLogDetailPage } from "@/components/RoastLogDetailPage";
+
+export const Route = createFileRoute("/logs/$logId/")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { logId } = Route.useParams();
+  return <RoastLogDetailPage logId={logId} />;
+}

--- a/src/routes/logs.new.tsx
+++ b/src/routes/logs.new.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { RoastLogCreatePage } from "@/components/RoastLogCreatePage";
+
+export const Route = createFileRoute("/logs/new")({
+  component: RoastLogCreatePage,
+});


### PR DESCRIPTION
## Summary

- `TimePicker` コンポーネント（react-mobile-picker MM:SS ドラムロール、nullable 対応）を TDD で実装
- `RoastLogForm`（TanStack Form + Zod バリデーション、WeightLossRate リアルタイム計算、shadcn Select/Textarea）を実装
- `RoastLogCreatePage`・`RoastLogDetailPage`・`RoastLogEditPage` を TDD で実装
- ルート `/logs/new`・`/logs/$logId`・`/logs/$logId/edit` を追加
- `RoastLogListPage` の CTA ボタン・カードクリックを各ルートへ配線
- shadcn `select`・`textarea` コンポーネントを追加
- 編集時は在庫を変動させない（ADR-0002 準拠）

## Test plan

- [x] `npm run test:run` が全件グリーン（141 tests）
- [x] `npm run build` が成功
- [x] pre-commit フック（lint・typecheck・arch:check）がすべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 焙煎ログの作成・詳細表示・編集を追加（重量損失率表示・検証・削除フロー含む）
  * 焙煎ログフォームの入力体験を改善（各種選択・時間ピッカー・数値/メモ入力）
  * 焙煎ログ一覧から個別ページへの直接ナビゲーションを実装

* **Tests**
  * 作成／詳細／編集／フォーム／タイムピッカーのテストスイートを追加

* **Chores**
  * モバイル向けピッカー依存を追加しました（外部パッケージ）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->