### PR TITLE
feat(slice-4): Bean Management デザイン実装

### DIFF
--- a/src/components/BeanCreatePage.tsx
+++ b/src/components/BeanCreatePage.tsx
@@ -1,6 +1,5 @@
-import { Link, useNavigate } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { BeanForm } from "@/components/BeanForm";
-import { buttonVariants } from "@/components/ui/button";
 import { useCreateBean } from "@/hooks/useMutateBean";
 import type { CreateBeanInput } from "@/schemas/bean";
 
@@ -13,6 +12,12 @@ const emptyDefaults: CreateBeanInput = {
   importedAt: null,
   stockG: 0,
   note: "",
+  totalG: 0,
+  flavorTagIds: [],
+  process: "",
+  region: "",
+  altitude: "",
+  variety: "",
 };
 
 export function BeanCreatePage() {
@@ -20,24 +25,50 @@ export function BeanCreatePage() {
   const { mutateAsync } = useCreateBean();
 
   return (
-    <div className="p-6">
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">生豆を追加</h1>
-        <Link to="/beans" className={buttonVariants({ variant: "outline" })}>
-          キャンセル
-        </Link>
-      </div>
-      <BeanForm
-        defaultValues={emptyDefaults}
-        submitLabel="登録"
-        onSubmit={async (input) => {
-          const bean = await mutateAsync(input);
-          await navigate({
-            to: "/beans/$beanId",
-            params: { beanId: bean.id },
-          });
+    <div
+      style={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+      }}
+    >
+      <header
+        style={{
+          flexShrink: 0,
+          height: 52,
+          display: "flex",
+          alignItems: "center",
+          padding: "0 16px",
+          background: "var(--background)",
+          borderBottom: "0.5px solid var(--border)",
         }}
-      />
+      >
+        <div
+          style={{
+            flex: 1,
+            fontWeight: 500,
+            fontSize: 18,
+            color: "var(--foreground)",
+          }}
+        >
+          豆を追加
+        </div>
+      </header>
+      <div style={{ flex: 1, overflowY: "auto", padding: "16px 16px 32px" }}>
+        <BeanForm
+          defaultValues={emptyDefaults}
+          submitLabel="登録"
+          onSubmit={async (input) => {
+            const bean = await mutateAsync(input);
+            await navigate({
+              to: "/beans/$beanId",
+              params: { beanId: bean.id },
+            });
+          }}
+          onCancel={() => navigate({ to: "/beans" })}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/BeanDetailPage.test.tsx
+++ b/src/components/BeanDetailPage.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/react-router";
 import { render, screen, waitFor } from "@testing-library/react/pure";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BeanDetailPage } from "@/components/BeanDetailPage";
 import { db } from "@/db";
 
@@ -44,30 +44,49 @@ function renderAt(beanId: string) {
   return router;
 }
 
+const BASE_BEAN = {
+  origin: "",
+  productName: "",
+  shopName: "",
+  purchasedAt: null,
+  importedAt: null,
+  stockG: 100,
+  bestLogId: null,
+  note: "",
+  totalG: 0,
+  flavorTagIds: [] as string[],
+  process: "",
+  region: "",
+  altitude: "",
+  variety: "",
+} as const;
+
 describe("BeanDetailPage", () => {
   beforeEach(async () => {
-    await db.beans.clear();
+    await Promise.all([
+      db.roastLevels.clear(),
+      db.flavorTags.clear(),
+      db.roastDevices.clear(),
+      db.beans.clear(),
+      db.roastLogs.clear(),
+    ]);
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("全フィールドと購入からの経過月数を表示する", async () => {
-    vi.useFakeTimers({ toFake: ["Date"] });
-    vi.setSystemTime(new Date("2026-05-02"));
-
+  it("スペックグリッドと在庫を表示する", async () => {
     const id = crypto.randomUUID();
     await db.beans.put({
+      ...BASE_BEAN,
       id,
       name: "エチオピア イルガチェフェ",
       origin: "エチオピア",
-      productName: "G1 ナチュラル",
+      region: "イルガチェフェ",
+      process: "Washed",
+      altitude: "1800m",
+      variety: "Heirloom",
       shopName: "丸山珈琲",
       purchasedAt: "2026-04-01",
-      importedAt: "2026-02-15",
       stockG: 320,
-      bestLogId: null,
+      totalG: 400,
       note: "フローラルで好み",
     });
 
@@ -77,29 +96,22 @@ describe("BeanDetailPage", () => {
       expect(screen.getByText("エチオピア イルガチェフェ")).toBeInTheDocument(),
     );
     expect(screen.getByText("エチオピア")).toBeInTheDocument();
-    expect(screen.getByText("G1 ナチュラル")).toBeInTheDocument();
+    expect(screen.getByText("イルガチェフェ")).toBeInTheDocument();
+    expect(screen.getByText("Washed")).toBeInTheDocument();
+    expect(screen.getByText("1800m")).toBeInTheDocument();
+    expect(screen.getByText("Heirloom")).toBeInTheDocument();
     expect(screen.getByText("丸山珈琲")).toBeInTheDocument();
-    expect(screen.getByText("320g")).toBeInTheDocument();
     expect(screen.getByText("2026-04-01")).toBeInTheDocument();
-    expect(screen.getByText("2026-02-15")).toBeInTheDocument();
     expect(screen.getByText("フローラルで好み")).toBeInTheDocument();
-    // 経過月数: 購入日 2026-04-01, 今日固定 2026-05-02 → 1 ヶ月
-    expect(screen.getByText(/1 ヶ月/)).toBeInTheDocument();
+    expect(screen.getByText("320")).toBeInTheDocument();
   });
 
   it("編集リンクで /beans/$beanId/edit に遷移できる", async () => {
     const id = crypto.randomUUID();
     await db.beans.put({
+      ...BASE_BEAN,
       id,
       name: "ブラジル",
-      origin: "",
-      productName: "",
-      shopName: "",
-      purchasedAt: null,
-      importedAt: null,
-      stockG: 100,
-      bestLogId: null,
-      note: "",
     });
     const user = userEvent.setup();
     const router = renderAt(id);
@@ -116,16 +128,9 @@ describe("BeanDetailPage", () => {
   it("削除を確認すると /beans に遷移する", async () => {
     const id = crypto.randomUUID();
     await db.beans.put({
+      ...BASE_BEAN,
       id,
       name: "コロンビア",
-      origin: "",
-      productName: "",
-      shopName: "",
-      purchasedAt: null,
-      importedAt: null,
-      stockG: 100,
-      bestLogId: null,
-      note: "",
     });
     const user = userEvent.setup();
     const router = renderAt(id);
@@ -144,16 +149,9 @@ describe("BeanDetailPage", () => {
   it("削除をキャンセルするとそのまま留まる", async () => {
     const id = crypto.randomUUID();
     await db.beans.put({
+      ...BASE_BEAN,
       id,
       name: "ケニア",
-      origin: "",
-      productName: "",
-      shopName: "",
-      purchasedAt: null,
-      importedAt: null,
-      stockG: 100,
-      bestLogId: null,
-      note: "",
     });
     const user = userEvent.setup();
     const router = renderAt(id);
@@ -165,5 +163,45 @@ describe("BeanDetailPage", () => {
     expect(router.state.location.pathname).toBe(`/beans/${id}`);
     expect(await db.beans.get(id)).toBeDefined();
     confirmSpy.mockRestore();
+  });
+
+  it("「在庫を更新」で増減モードが動作する", async () => {
+    const id = crypto.randomUUID();
+    await db.beans.put({
+      ...BASE_BEAN,
+      id,
+      name: "グアテマラ",
+      stockG: 200,
+      totalG: 400,
+    });
+
+    const user = userEvent.setup();
+    renderAt(id);
+
+    await waitFor(() =>
+      expect(screen.getByText("グアテマラ")).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("button", { name: "在庫を更新" }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    await user.type(screen.getByLabelText(/増減量/), "-50");
+    expect(screen.getByText("150g")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "更新する" }));
+
+    await waitFor(async () => {
+      const stored = await db.beans.get(id);
+      expect(stored?.stockG).toBe(150);
+    });
+  });
+
+  it("焙煎履歴がない場合「まだ焙煎していません」を表示する", async () => {
+    const id = crypto.randomUUID();
+    await db.beans.put({ ...BASE_BEAN, id, name: "パナマ" });
+
+    renderAt(id);
+    await waitFor(() => expect(screen.getByText("パナマ")).toBeInTheDocument());
+    expect(screen.getByText("まだ焙煎していません")).toBeInTheDocument();
   });
 });

--- a/src/components/BeanDetailPage.tsx
+++ b/src/components/BeanDetailPage.tsx
@@ -77,10 +77,13 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
   const beanLogs = logs
     .filter((l) => l.beanId === beanId)
     .sort((a, b) => b.roastDate.localeCompare(a.roastDate));
-  const bestLog = beanLogs.reduce<(typeof beanLogs)[0] | null>((best, log) => {
-    if (!best || (log.overallScore ?? 0) > (best.overallScore ?? 0)) return log;
-    return best;
-  }, null);
+  const bestLog = beanLogs
+    .filter((log) => log.overallScore != null)
+    .reduce<(typeof beanLogs)[0] | null>((best, log) => {
+      if (!best || (log.overallScore ?? 0) > (best.overallScore ?? 0))
+        return log;
+      return best;
+    }, null);
 
   const pct = stockPct(bean);
 

--- a/src/components/BeanDetailPage.tsx
+++ b/src/components/BeanDetailPage.tsx
@@ -1,83 +1,739 @@
 import { Link, useNavigate } from "@tanstack/react-router";
-import { Button, buttonVariants } from "@/components/ui/button";
-import { monthsSincePurchase } from "@/domain/bean";
+import { useState } from "react";
+import { RoastBadge } from "@/components/RoastBadge";
+import { StarRating } from "@/components/StarRating";
+import { calcWeightLossRate } from "@/domain/roastLog";
 import { useBean } from "@/hooks/useBeans";
-import { useDeleteBean } from "@/hooks/useMutateBean";
+import { useFlavorTags } from "@/hooks/useFlavorTags";
+import { useDeleteBean, useUpdateBean } from "@/hooks/useMutateBean";
+import { useRoastLevels } from "@/hooks/useRoastLevels";
+import { useRoastLogs } from "@/hooks/useRoastLogs";
+import type { Bean } from "@/schemas/bean";
 
-function Field({ label, value }: { label: string; value: string }) {
+function stockPct(bean: Bean): number {
+  if (bean.totalG > 0) return (bean.stockG / bean.totalG) * 100;
+  return bean.stockG > 0 ? 100 : 0;
+}
+
+function StockBar({ pct }: { pct: number }) {
+  let color = "#2D7D52";
+  if (pct === 0) color = "var(--border)";
+  else if (pct < 20) color = "#B83232";
+  else if (pct < 50) color = "#D4943A";
   return (
-    <div className="flex flex-col gap-1">
-      <span className="text-xs text-muted-foreground">{label}</span>
-      <span className="text-sm">{value || "—"}</span>
+    <div
+      style={{
+        height: 4,
+        background: "var(--border)",
+        borderRadius: 2,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          height: "100%",
+          width: `${Math.max(0, Math.min(100, pct))}%`,
+          background: color,
+          borderRadius: 2,
+        }}
+      />
     </div>
   );
 }
 
 export function BeanDetailPage({ beanId }: { beanId: string }) {
   const navigate = useNavigate();
-  const { data: bean, isLoading } = useBean(beanId);
+  const { data: bean, isLoading: beanLoading } = useBean(beanId);
+  const { data: logs = [], isLoading: logsLoading } = useRoastLogs();
+  const { data: levels = [], isLoading: levelsLoading } = useRoastLevels();
+  const { data: flavorTags = [], isLoading: tagsLoading } = useFlavorTags();
   const { mutateAsync: deleteBean } = useDeleteBean();
+  const { mutateAsync: updateBean } = useUpdateBean();
 
-  if (isLoading) return null;
+  const [stockSheet, setStockSheet] = useState(false);
+  const [adjustAmt, setAdjustAmt] = useState("");
+  const [adjustMode, setAdjustMode] = useState<"add" | "set">("add");
+
+  if (beanLoading || logsLoading || levelsLoading || tagsLoading) return null;
+
   if (!bean) {
     return (
-      <div className="p-6">
-        <p className="text-muted-foreground">生豆が見つかりません</p>
-        <Link to="/beans" className={buttonVariants({ variant: "outline" })}>
+      <div style={{ padding: 24 }}>
+        <p style={{ color: "var(--muted-foreground)", marginBottom: 12 }}>
+          生豆が見つかりません
+        </p>
+        <Link
+          to="/beans"
+          style={{ color: "var(--primary)", textDecoration: "none" }}
+        >
           一覧へ戻る
         </Link>
       </div>
     );
   }
 
-  const months = monthsSincePurchase(bean.purchasedAt, new Date());
+  const levelMap = Object.fromEntries(levels.map((l) => [l.id, l]));
+  const tagMap = Object.fromEntries(flavorTags.map((t) => [t.id, t]));
+  const beanLogs = logs
+    .filter((l) => l.beanId === beanId)
+    .sort((a, b) => b.roastDate.localeCompare(a.roastDate));
+  const bestLog = beanLogs.reduce<(typeof beanLogs)[0] | null>((best, log) => {
+    if (!best || (log.overallScore ?? 0) > (best.overallScore ?? 0)) return log;
+    return best;
+  }, null);
+
+  const pct = stockPct(bean);
+
+  async function handleStockSave() {
+    if (!bean) return;
+    const amt = parseInt(adjustAmt, 10);
+    if (Number.isNaN(amt)) return;
+    const newG =
+      adjustMode === "set" ? Math.max(0, amt) : Math.max(0, bean.stockG + amt);
+    await updateBean({ ...bean, stockG: newG });
+    setStockSheet(false);
+    setAdjustAmt("");
+  }
+
+  const previewG =
+    adjustMode === "add" &&
+    adjustAmt !== "" &&
+    !Number.isNaN(parseInt(adjustAmt, 10))
+      ? Math.max(0, bean.stockG + parseInt(adjustAmt, 10))
+      : null;
+
+  const specRows = [
+    { k: "産地", v: bean.origin },
+    { k: "地域", v: bean.region },
+    { k: "精製", v: bean.process },
+    { k: "標高", v: bean.altitude },
+    { k: "品種", v: bean.variety },
+    { k: "購入先", v: bean.shopName },
+    { k: "購入日", v: bean.purchasedAt ?? "" },
+  ];
 
   return (
-    <div className="p-6 flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">{bean.name}</h1>
-        <div className="flex gap-2">
-          <Link
-            to="/beans/$beanId/edit"
-            params={{ beanId: bean.id }}
-            className={buttonVariants({ variant: "outline" })}
+    <div
+      style={{
+        position: "relative",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* Header */}
+      <header
+        style={{
+          flexShrink: 0,
+          height: 52,
+          display: "flex",
+          alignItems: "center",
+          padding: "0 8px",
+          background: "var(--background)",
+          borderBottom: "0.5px solid var(--border)",
+        }}
+      >
+        <button
+          type="button"
+          aria-label="戻る"
+          onClick={() => navigate({ to: "/beans" })}
+          style={{
+            width: 44,
+            height: 44,
+            background: "transparent",
+            border: 0,
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "var(--primary)",
+          }}
+        >
+          <svg
+            aria-hidden="true"
+            width="22"
+            height="22"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
           >
-            編集
-          </Link>
-          <Button
-            variant="destructive"
-            onClick={async () => {
-              if (!window.confirm("この生豆を削除しますか？")) return;
-              await deleteBean(bean.id);
-              await navigate({ to: "/beans" });
+            <path d="M15 18l-6-6 6-6" />
+          </svg>
+        </button>
+        <div
+          style={{
+            flex: 1,
+            textAlign: "center",
+            fontWeight: 500,
+            fontSize: 18,
+            color: "var(--foreground)",
+          }}
+        >
+          豆の詳細
+        </div>
+        <Link
+          to="/beans/$beanId/edit"
+          params={{ beanId: bean.id }}
+          style={{
+            height: 32,
+            padding: "0 12px",
+            display: "inline-flex",
+            alignItems: "center",
+            color: "var(--primary)",
+            fontSize: 14,
+            fontWeight: 500,
+            textDecoration: "none",
+          }}
+        >
+          編集
+        </Link>
+      </header>
+
+      <div style={{ flex: 1, overflowY: "auto", padding: "8px 16px 32px" }}>
+        {/* Hero */}
+        <div style={{ marginBottom: 16 }}>
+          <div
+            style={{
+              fontFamily: "Georgia, serif",
+              fontSize: 24,
+              fontWeight: 500,
+              lineHeight: 1.25,
+              color: "var(--foreground)",
             }}
           >
-            削除
-          </Button>
+            {bean.name}
+          </div>
+          <div
+            style={{
+              fontSize: 12,
+              color: "var(--muted-foreground)",
+              marginTop: 4,
+            }}
+          >
+            {[bean.origin, bean.region, bean.process]
+              .filter(Boolean)
+              .join(" · ")}
+          </div>
+          {bean.flavorTagIds.length > 0 && (
+            <div
+              style={{
+                marginTop: 8,
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 5,
+              }}
+            >
+              {bean.flavorTagIds.map((tid) => {
+                const tag = tagMap[tid];
+                if (!tag) return null;
+                return (
+                  <span
+                    key={tid}
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 5,
+                      padding: "3px 8px",
+                      borderRadius: 999,
+                      fontSize: 11,
+                      fontWeight: 500,
+                      background: `${tag.color}1A`,
+                      color: tag.color,
+                      border: `0.5px solid ${tag.color}33`,
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 6,
+                        height: 6,
+                        borderRadius: "50%",
+                        background: tag.color,
+                      }}
+                    />
+                    {tag.name}
+                  </span>
+                );
+              })}
+            </div>
+          )}
         </div>
+
+        {/* Stock card */}
+        <div
+          style={{
+            background: "var(--card)",
+            border: "0.5px solid var(--border)",
+            borderRadius: 10,
+            padding: "14px 16px",
+            boxShadow: "0 1px 2px rgba(28,23,20,0.04)",
+            marginBottom: 12,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "flex-end",
+              marginBottom: 10,
+            }}
+          >
+            <div>
+              <div
+                style={{
+                  fontSize: 11,
+                  color: "var(--muted-foreground)",
+                  marginBottom: 4,
+                }}
+              >
+                在庫
+              </div>
+              <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+                <span
+                  style={{
+                    fontFamily: "Georgia, serif",
+                    fontSize: 28,
+                    fontWeight: 500,
+                    fontVariantNumeric: "tabular-nums",
+                    color:
+                      pct < 20 && pct > 0
+                        ? "#B83232"
+                        : pct === 0
+                          ? "var(--muted-foreground)"
+                          : "var(--foreground)",
+                  }}
+                >
+                  {bean.stockG}
+                </span>
+                <span
+                  style={{ fontSize: 13, color: "var(--muted-foreground)" }}
+                >
+                  g{bean.totalG > 0 ? ` / ${bean.totalG}g` : ""}
+                </span>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setStockSheet(true)}
+              style={{
+                height: 36,
+                padding: "0 14px",
+                background: "var(--primary)",
+                color: "var(--primary-foreground)",
+                border: 0,
+                borderRadius: 8,
+                fontSize: 12,
+                fontWeight: 500,
+                cursor: "pointer",
+              }}
+            >
+              在庫を更新
+            </button>
+          </div>
+          <StockBar pct={pct} />
+          <div
+            style={{
+              marginTop: 6,
+              fontFamily: "ui-monospace, monospace",
+              fontSize: 11,
+              color: "var(--muted-foreground)",
+            }}
+          >
+            残 {Math.round(pct)}%
+          </div>
+        </div>
+
+        {/* Spec grid */}
+        <div
+          style={{
+            background: "var(--card)",
+            border: "0.5px solid var(--border)",
+            borderRadius: 10,
+            overflow: "hidden",
+            boxShadow: "0 1px 2px rgba(28,23,20,0.04)",
+            marginBottom: 12,
+          }}
+        >
+          {specRows.map((row, i) => (
+            <div
+              key={row.k}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                padding: "10px 14px",
+                borderTop: i > 0 ? "0.5px solid var(--border)" : "none",
+              }}
+            >
+              <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
+                {row.k}
+              </span>
+              <span style={{ fontSize: 13, fontWeight: 500 }}>
+                {row.v || "—"}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Notes */}
+        {bean.note && (
+          <div
+            style={{
+              background: "var(--muted)",
+              borderRadius: 10,
+              padding: "10px 14px",
+              marginBottom: 16,
+              fontFamily: "Georgia, serif",
+              fontSize: 13,
+              lineHeight: 1.65,
+              color: "var(--foreground)",
+            }}
+          >
+            {bean.note}
+          </div>
+        )}
+
+        {/* Roast history */}
+        <div style={{ marginBottom: 16 }}>
+          <div
+            style={{
+              fontSize: 11,
+              letterSpacing: "0.06em",
+              color: "var(--muted-foreground)",
+              marginBottom: 8,
+              paddingLeft: 2,
+            }}
+          >
+            焙煎履歴 ({beanLogs.length}回)
+          </div>
+          {beanLogs.length === 0 ? (
+            <div
+              style={{
+                background: "var(--card)",
+                border: "0.5px solid var(--border)",
+                borderRadius: 10,
+                padding: "24px 0",
+                textAlign: "center",
+                fontSize: 13,
+                color: "var(--muted-foreground)",
+              }}
+            >
+              まだ焙煎していません
+            </div>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              {beanLogs.map((log) => {
+                const level = levelMap[log.roastLevelId];
+                const isBest = bestLog?.id === log.id;
+                const rate = calcWeightLossRate(
+                  log.weightBeforeG,
+                  log.weightAfterG,
+                );
+                return (
+                  <div
+                    key={log.id}
+                    style={{
+                      background: "var(--card)",
+                      border: `0.5px solid ${isBest ? "#2D7D52" : "var(--border)"}`,
+                      borderRadius: 10,
+                      padding: "10px 14px",
+                      boxShadow: "0 1px 2px rgba(28,23,20,0.04)",
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      gap: 8,
+                    }}
+                  >
+                    <div>
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 6,
+                          marginBottom: 4,
+                        }}
+                      >
+                        {level && <RoastBadge level={level} size="sm" />}
+                        {isBest && (
+                          <span
+                            style={{
+                              fontSize: 10,
+                              fontWeight: 500,
+                              padding: "2px 7px",
+                              borderRadius: 999,
+                              background: "#E0F2E9",
+                              color: "#2D7D52",
+                            }}
+                          >
+                            ベスト
+                          </span>
+                        )}
+                      </div>
+                      <div
+                        style={{
+                          fontFamily: "ui-monospace, monospace",
+                          fontSize: 11,
+                          color: "var(--muted-foreground)",
+                        }}
+                      >
+                        {log.roastDate}
+                      </div>
+                    </div>
+                    <div style={{ textAlign: "right" }}>
+                      <div
+                        style={{
+                          display: "flex",
+                          justifyContent: "flex-end",
+                          marginBottom: 2,
+                        }}
+                      >
+                        <StarRating value={log.overallScore} size={12} />
+                      </div>
+                      <div
+                        style={{
+                          fontFamily: "ui-monospace, monospace",
+                          fontSize: 11,
+                          color: "var(--muted-foreground)",
+                        }}
+                      >
+                        {log.weightBeforeG}g → {log.weightAfterG}g ·{" "}
+                        {rate.toFixed(1)}%
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Delete */}
+        <button
+          type="button"
+          onClick={async () => {
+            if (!window.confirm("この生豆を削除しますか？")) return;
+            await deleteBean(bean.id);
+            await navigate({ to: "/beans" });
+          }}
+          style={{
+            width: "100%",
+            height: 44,
+            borderRadius: 10,
+            border: "0.5px solid #B83232",
+            background: "transparent",
+            color: "#B83232",
+            fontSize: 14,
+            fontWeight: 500,
+            cursor: "pointer",
+          }}
+        >
+          削除
+        </button>
       </div>
 
-      <section className="grid grid-cols-2 gap-4">
-        <Field label="産地" value={bean.origin} />
-        <Field label="製品名" value={bean.productName} />
-        <Field label="購入店" value={bean.shopName} />
-        <Field label="在庫" value={`${bean.stockG}g`} />
-        <Field label="購入日" value={bean.purchasedAt ?? ""} />
-        <Field label="輸入時期" value={bean.importedAt ?? ""} />
-        <Field
-          label="購入からの経過月数"
-          value={months === null ? "" : `${months} ヶ月`}
-        />
-      </section>
+      {/* Stock update sheet */}
+      {stockSheet && (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            zIndex: 20,
+            display: "flex",
+            alignItems: "flex-end",
+          }}
+        >
+          {/* backdrop */}
+          <button
+            type="button"
+            aria-label="シートを閉じる"
+            onClick={() => {
+              setStockSheet(false);
+              setAdjustAmt("");
+            }}
+            style={{
+              position: "absolute",
+              inset: 0,
+              background: "rgba(28,23,20,0.4)",
+              border: 0,
+              cursor: "default",
+            }}
+          />
+          <div
+            role="dialog"
+            aria-labelledby="stock-sheet-title"
+            aria-modal="true"
+            style={{
+              position: "relative",
+              width: "100%",
+              background: "var(--card)",
+              borderTopLeftRadius: 16,
+              borderTopRightRadius: 16,
+              boxShadow: "0 -4px 20px rgba(28,23,20,0.12)",
+              padding: "14px 16px 32px",
+            }}
+          >
+            <div
+              style={{
+                width: 36,
+                height: 4,
+                background: "var(--border)",
+                borderRadius: 2,
+                margin: "0 auto 14px",
+              }}
+            />
+            <h3
+              id="stock-sheet-title"
+              style={{ fontSize: 18, fontWeight: 500, marginBottom: 16 }}
+            >
+              在庫を更新
+            </h3>
 
-      <section>
-        <h2 className="mb-1 text-xs text-muted-foreground">メモ</h2>
-        <p className="text-sm whitespace-pre-wrap">{bean.note || "—"}</p>
-      </section>
+            <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+              {/* Mode toggle */}
+              <div style={{ display: "flex", gap: 6 }}>
+                {(["add", "set"] as const).map((m) => (
+                  <button
+                    key={m}
+                    type="button"
+                    onClick={() => setAdjustMode(m)}
+                    style={{
+                      flex: 1,
+                      height: 38,
+                      borderRadius: 8,
+                      fontSize: 13,
+                      fontWeight: 500,
+                      cursor: "pointer",
+                      background:
+                        adjustMode === m ? "var(--primary)" : "var(--muted)",
+                      color:
+                        adjustMode === m
+                          ? "var(--primary-foreground)"
+                          : "var(--muted-foreground)",
+                      border: "0.5px solid transparent",
+                    }}
+                  >
+                    {m === "add" ? "増減" : "直接入力"}
+                  </button>
+                ))}
+              </div>
 
-      <section className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
-        RoastLog 履歴・BestRecipe は次のスライスで実装
-      </section>
+              {/* Input */}
+              <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                <label
+                  htmlFor="adjust-input"
+                  style={{
+                    fontSize: 12,
+                    fontWeight: 500,
+                    color: "var(--muted-foreground)",
+                  }}
+                >
+                  {adjustMode === "add"
+                    ? "増減量（例: -50 で減量）"
+                    : "現在の在庫量（g）"}
+                </label>
+                <div style={{ position: "relative" }}>
+                  <input
+                    id="adjust-input"
+                    type="number"
+                    value={adjustAmt}
+                    onChange={(e) => setAdjustAmt(e.target.value)}
+                    style={{
+                      width: "100%",
+                      height: 44,
+                      padding: "0 40px 0 12px",
+                      background: "var(--muted)",
+                      border: "0.5px solid var(--border)",
+                      borderRadius: 8,
+                      fontSize: 14,
+                      fontFamily: "ui-monospace, monospace",
+                      color: "var(--foreground)",
+                      outline: "none",
+                      boxSizing: "border-box",
+                    }}
+                  />
+                  <span
+                    style={{
+                      position: "absolute",
+                      right: 12,
+                      top: "50%",
+                      transform: "translateY(-50%)",
+                      fontSize: 13,
+                      color: "var(--muted-foreground)",
+                      pointerEvents: "none",
+                    }}
+                  >
+                    g
+                  </span>
+                </div>
+              </div>
+
+              {/* Preview */}
+              {previewG !== null && (
+                <div
+                  style={{
+                    background: "var(--muted)",
+                    borderRadius: 8,
+                    padding: "10px 14px",
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: 12,
+                      color: "var(--muted-foreground)",
+                    }}
+                  >
+                    更新後
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: "Georgia, serif",
+                      fontSize: 18,
+                      fontWeight: 500,
+                      fontVariantNumeric: "tabular-nums",
+                    }}
+                  >
+                    {previewG}g
+                  </span>
+                </div>
+              )}
+
+              {/* Save */}
+              <button
+                type="button"
+                onClick={handleStockSave}
+                disabled={!adjustAmt || Number.isNaN(parseInt(adjustAmt, 10))}
+                style={{
+                  width: "100%",
+                  height: 50,
+                  borderRadius: 10,
+                  border: 0,
+                  background:
+                    !adjustAmt || Number.isNaN(parseInt(adjustAmt, 10))
+                      ? "var(--muted)"
+                      : "var(--primary)",
+                  color:
+                    !adjustAmt || Number.isNaN(parseInt(adjustAmt, 10))
+                      ? "var(--muted-foreground)"
+                      : "var(--primary-foreground)",
+                  fontSize: 15,
+                  fontWeight: 600,
+                  cursor:
+                    !adjustAmt || Number.isNaN(parseInt(adjustAmt, 10))
+                      ? "default"
+                      : "pointer",
+                }}
+              >
+                更新する
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/BeanEditPage.test.tsx
+++ b/src/components/BeanEditPage.test.tsx
@@ -63,6 +63,12 @@ describe("BeanEditPage", () => {
       stockG: 200,
       bestLogId: null,
       note: "",
+      totalG: 0,
+      flavorTagIds: [],
+      process: "",
+      region: "",
+      altitude: "",
+      variety: "",
     });
 
     const user = userEvent.setup();

--- a/src/components/BeanEditPage.tsx
+++ b/src/components/BeanEditPage.tsx
@@ -1,6 +1,5 @@
-import { Link, useNavigate } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { BeanForm } from "@/components/BeanForm";
-import { buttonVariants } from "@/components/ui/button";
 import { useBean } from "@/hooks/useBeans";
 import { useUpdateBean } from "@/hooks/useMutateBean";
 
@@ -12,50 +11,111 @@ export function BeanEditPage({ beanId }: { beanId: string }) {
   if (isLoading) return null;
   if (!bean) {
     return (
-      <div className="p-6">
-        <p className="text-muted-foreground">生豆が見つかりません</p>
-        <Link to="/beans" className={buttonVariants({ variant: "outline" })}>
-          一覧へ戻る
-        </Link>
+      <div style={{ padding: 24 }}>
+        <p style={{ color: "var(--muted-foreground)" }}>生豆が見つかりません</p>
       </div>
     );
   }
 
   return (
-    <div className="p-6">
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">{bean.name} を編集</h1>
-        <Link
-          to="/beans/$beanId"
-          params={{ beanId: bean.id }}
-          className={buttonVariants({ variant: "outline" })}
+    <div
+      style={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+      }}
+    >
+      <header
+        style={{
+          flexShrink: 0,
+          height: 52,
+          display: "flex",
+          alignItems: "center",
+          padding: "0 8px",
+          background: "var(--background)",
+          borderBottom: "0.5px solid var(--border)",
+        }}
+      >
+        <button
+          type="button"
+          aria-label="戻る"
+          onClick={() =>
+            navigate({ to: "/beans/$beanId", params: { beanId: bean.id } })
+          }
+          style={{
+            width: 44,
+            height: 44,
+            background: "transparent",
+            border: 0,
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "var(--primary)",
+          }}
         >
-          キャンセル
-        </Link>
+          <svg
+            aria-hidden="true"
+            width="22"
+            height="22"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M15 18l-6-6 6-6" />
+          </svg>
+        </button>
+        <div
+          style={{
+            flex: 1,
+            fontWeight: 500,
+            fontSize: 18,
+            color: "var(--foreground)",
+            paddingRight: 44,
+            textAlign: "center",
+          }}
+        >
+          豆を編集
+        </div>
+      </header>
+      <div style={{ flex: 1, overflowY: "auto", padding: "16px 16px 32px" }}>
+        <BeanForm
+          defaultValues={{
+            name: bean.name,
+            origin: bean.origin,
+            productName: bean.productName,
+            shopName: bean.shopName,
+            purchasedAt: bean.purchasedAt,
+            importedAt: bean.importedAt,
+            stockG: bean.stockG,
+            note: bean.note,
+            totalG: bean.totalG,
+            flavorTagIds: bean.flavorTagIds,
+            process: bean.process,
+            region: bean.region,
+            altitude: bean.altitude,
+            variety: bean.variety,
+          }}
+          submitLabel="保存"
+          onSubmit={async (input) => {
+            await updateBean({
+              ...bean,
+              ...input,
+            });
+            await navigate({
+              to: "/beans/$beanId",
+              params: { beanId: bean.id },
+            });
+          }}
+          onCancel={() =>
+            navigate({ to: "/beans/$beanId", params: { beanId: bean.id } })
+          }
+        />
       </div>
-      <BeanForm
-        defaultValues={{
-          name: bean.name,
-          origin: bean.origin,
-          productName: bean.productName,
-          shopName: bean.shopName,
-          purchasedAt: bean.purchasedAt,
-          importedAt: bean.importedAt,
-          stockG: bean.stockG,
-          note: bean.note,
-        }}
-        submitLabel="保存"
-        onSubmit={async (input) => {
-          await updateBean({
-            ...bean,
-            ...input,
-          });
-          await navigate({
-            to: "/beans/$beanId",
-            params: { beanId: bean.id },
-          });
-        }}
-      />
     </div>
   );
 }

--- a/src/components/BeanForm.test.tsx
+++ b/src/components/BeanForm.test.tsx
@@ -1,7 +1,9 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react/pure";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BeanForm } from "@/components/BeanForm";
+import { db } from "@/db";
 import type { CreateBeanInput } from "@/schemas/bean";
 
 const emptyDefaults: CreateBeanInput = {
@@ -13,56 +15,67 @@ const emptyDefaults: CreateBeanInput = {
   importedAt: null,
   stockG: 0,
   note: "",
+  totalG: 0,
+  flavorTagIds: [],
+  process: "",
+  region: "",
+  altitude: "",
+  variety: "",
 };
 
-describe("BeanForm", () => {
-  it("全フィールドを入力して送信できる", async () => {
-    const user = userEvent.setup();
-    const onSubmit = vi.fn();
-    render(
+function renderForm(props: Partial<Parameters<typeof BeanForm>[0]> = {}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
       <BeanForm
         defaultValues={emptyDefaults}
-        onSubmit={onSubmit}
+        onSubmit={() => {}}
         submitLabel="登録"
-      />,
-    );
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("BeanForm", () => {
+  beforeEach(async () => {
+    await Promise.all([
+      db.roastLevels.clear(),
+      db.flavorTags.clear(),
+      db.roastDevices.clear(),
+      db.beans.clear(),
+      db.roastLogs.clear(),
+    ]);
+  });
+
+  it("名前・産地・在庫を入力して送信できる", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderForm({ onSubmit });
 
     await user.type(screen.getByLabelText("名前"), "エチオピア イルガチェフェ");
     await user.type(screen.getByLabelText("産地"), "エチオピア");
-    await user.type(screen.getByLabelText("製品名"), "G1 ナチュラル");
-    await user.type(screen.getByLabelText("購入店"), "丸山珈琲");
-    await user.type(screen.getByLabelText("購入日"), "2024-01-15");
-    await user.type(screen.getByLabelText("輸入時期"), "2023-12-01");
     await user.clear(screen.getByLabelText("在庫 (g)"));
     await user.type(screen.getByLabelText("在庫 (g)"), "500");
-    await user.type(screen.getByLabelText("メモ"), "test note");
 
     await user.click(screen.getByRole("button", { name: "登録" }));
 
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith({
-        name: "エチオピア イルガチェフェ",
-        origin: "エチオピア",
-        productName: "G1 ナチュラル",
-        shopName: "丸山珈琲",
-        purchasedAt: "2024-01-15",
-        importedAt: "2023-12-01",
-        stockG: 500,
-        note: "test note",
-      });
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "エチオピア イルガチェフェ",
+          origin: "エチオピア",
+          stockG: 500,
+        }),
+      );
     });
   });
 
   it("name が空のまま送信するとバリデーションエラーメッセージが表示される", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
-    render(
-      <BeanForm
-        defaultValues={emptyDefaults}
-        onSubmit={onSubmit}
-        submitLabel="登録"
-      />,
-    );
+    renderForm({ onSubmit });
+
     await user.click(screen.getByRole("button", { name: "登録" }));
 
     await waitFor(() =>
@@ -72,23 +85,66 @@ describe("BeanForm", () => {
   });
 
   it("defaultValues を初期値として表示する", async () => {
-    const onSubmit = vi.fn();
-    render(
-      <BeanForm
-        defaultValues={{
-          ...emptyDefaults,
-          name: "ブラジル セラード",
-          stockG: 250,
-        }}
-        onSubmit={onSubmit}
-        submitLabel="保存"
-      />,
-    );
+    renderForm({
+      defaultValues: {
+        ...emptyDefaults,
+        name: "ブラジル セラード",
+        stockG: 250,
+        region: "セラード",
+      },
+    });
     expect(screen.getByLabelText<HTMLInputElement>("名前").value).toBe(
       "ブラジル セラード",
     );
     expect(screen.getByLabelText<HTMLInputElement>("在庫 (g)").value).toBe(
       "250",
     );
+    expect(screen.getByLabelText<HTMLInputElement>("地域").value).toBe(
+      "セラード",
+    );
+  });
+
+  it("精製方法トグルで process が変わる", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderForm({ onSubmit });
+
+    await user.type(screen.getByLabelText("名前"), "テスト豆");
+    await user.click(screen.getByRole("button", { name: "Natural" }));
+    await user.click(screen.getByRole("button", { name: "登録" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ process: "Natural" }),
+      );
+    });
+  });
+
+  it("フレーバータグがDBにあれば選択できる", async () => {
+    await db.flavorTags.put({
+      id: "floral",
+      name: "フローラル",
+      color: "#F9A8D4",
+    });
+
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderForm({ onSubmit });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /フローラル/ }),
+      ).toBeInTheDocument(),
+    );
+
+    await user.type(screen.getByLabelText("名前"), "テスト豆");
+    await user.click(screen.getByRole("button", { name: /フローラル/ }));
+    await user.click(screen.getByRole("button", { name: "登録" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ flavorTagIds: ["floral"] }),
+      );
+    });
   });
 });

--- a/src/components/BeanForm.tsx
+++ b/src/components/BeanForm.tsx
@@ -1,9 +1,9 @@
 import { useForm } from "@tanstack/react-form";
 import { z } from "zod";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { useFlavorTags } from "@/hooks/useFlavorTags";
 import type { CreateBeanInput } from "@/schemas/bean";
+
+const PROCESSES = ["Washed", "Natural", "Honey", "Anaerobic"] as const;
 
 const FormSchema = z.object({
   name: z.string().min(1, "名前は必須です"),
@@ -14,6 +14,12 @@ const FormSchema = z.object({
   importedAt: z.string(),
   stockG: z.number(),
   note: z.string(),
+  totalG: z.number(),
+  flavorTagIds: z.array(z.string()),
+  process: z.string(),
+  region: z.string(),
+  altitude: z.string(),
+  variety: z.string(),
 });
 
 type FormValues = z.infer<typeof FormSchema>;
@@ -28,6 +34,12 @@ function toFormValues(input: CreateBeanInput): FormValues {
     importedAt: input.importedAt ?? "",
     stockG: input.stockG,
     note: input.note,
+    totalG: input.totalG ?? 0,
+    flavorTagIds: input.flavorTagIds ?? [],
+    process: input.process ?? "",
+    region: input.region ?? "",
+    altitude: input.altitude ?? "",
+    variety: input.variety ?? "",
   };
 }
 
@@ -39,15 +51,83 @@ function toCreateInput(values: FormValues): CreateBeanInput {
   };
 }
 
+function FieldLabel({
+  htmlFor,
+  children,
+}: {
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label
+      htmlFor={htmlFor}
+      style={{
+        fontSize: 12,
+        fontWeight: 500,
+        color: "var(--muted-foreground)",
+        marginBottom: 6,
+        display: "block",
+      }}
+    >
+      {children}
+    </label>
+  );
+}
+
+function TextInput({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+  type = "text",
+}: {
+  id: string;
+  label: string;
+  value: string | number;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  type?: string;
+}) {
+  return (
+    <div>
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <input
+        id={id}
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        style={{
+          width: "100%",
+          height: 44,
+          padding: "0 12px",
+          background: "var(--muted)",
+          border: "0.5px solid var(--border)",
+          borderRadius: 8,
+          fontSize: 14,
+          color: "var(--foreground)",
+          outline: "none",
+          boxSizing: "border-box",
+        }}
+      />
+    </div>
+  );
+}
+
 export function BeanForm({
   defaultValues,
   onSubmit,
   submitLabel,
+  onCancel,
 }: {
   defaultValues: CreateBeanInput;
   onSubmit: (input: CreateBeanInput) => void | Promise<void>;
   submitLabel: string;
+  onCancel?: () => void;
 }) {
+  const { data: flavorTags = [] } = useFlavorTags();
+
   const form = useForm({
     defaultValues: toFormValues(defaultValues),
     validators: { onSubmit: FormSchema },
@@ -62,23 +142,43 @@ export function BeanForm({
         e.preventDefault();
         form.handleSubmit();
       }}
-      className="flex flex-col gap-4"
+      style={{ display: "flex", flexDirection: "column", gap: 16 }}
     >
+      {/* 名前 */}
       <form.Field name="name">
         {(field) => (
-          <div className="flex flex-col gap-1">
-            <Label htmlFor="bean-name">名前</Label>
-            <Input
+          <div>
+            <FieldLabel htmlFor="bean-name">名前</FieldLabel>
+            <input
               id="bean-name"
+              type="text"
               value={field.state.value}
               onChange={(e) => field.handleChange(e.target.value)}
+              placeholder="例: エチオピア イルガチェフェ"
+              style={{
+                width: "100%",
+                height: 44,
+                padding: "0 12px",
+                background: "var(--muted)",
+                border: `0.5px solid ${field.state.meta.errors.length > 0 ? "#B83232" : "var(--border)"}`,
+                borderRadius: 8,
+                fontSize: 14,
+                color: "var(--foreground)",
+                outline: "none",
+                boxSizing: "border-box",
+              }}
             />
             {field.state.meta.errors.map((err) =>
               err ? (
                 <span
                   key={err.message}
                   role="alert"
-                  className="text-sm text-destructive"
+                  style={{
+                    fontSize: 12,
+                    color: "#B83232",
+                    marginTop: 4,
+                    display: "block",
+                  }}
                 >
                   {err.message}
                 </span>
@@ -88,101 +188,280 @@ export function BeanForm({
         )}
       </form.Field>
 
+      {/* 産地 */}
       <form.Field name="origin">
         {(field) => (
-          <div className="flex flex-col gap-1">
-            <Label htmlFor="bean-origin">産地</Label>
-            <Input
-              id="bean-origin"
-              value={field.state.value}
-              onChange={(e) => field.handleChange(e.target.value)}
-            />
+          <TextInput
+            id="bean-origin"
+            label="産地"
+            value={field.state.value}
+            onChange={field.handleChange}
+            placeholder="例: エチオピア"
+          />
+        )}
+      </form.Field>
+
+      {/* 地域 */}
+      <form.Field name="region">
+        {(field) => (
+          <TextInput
+            id="bean-region"
+            label="地域"
+            value={field.state.value}
+            onChange={field.handleChange}
+            placeholder="例: イルガチェフェ"
+          />
+        )}
+      </form.Field>
+
+      {/* 精製方法 */}
+      <form.Field name="process">
+        {(field) => (
+          <div>
+            <FieldLabel htmlFor="bean-process">精製方法</FieldLabel>
+            <div style={{ display: "flex", gap: 6 }}>
+              {PROCESSES.map((p) => (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => field.handleChange(p)}
+                  style={{
+                    flex: 1,
+                    height: 38,
+                    borderRadius: 8,
+                    fontSize: 11,
+                    fontWeight: 500,
+                    cursor: "pointer",
+                    background:
+                      field.state.value === p
+                        ? "var(--primary)"
+                        : "var(--muted)",
+                    color:
+                      field.state.value === p
+                        ? "var(--primary-foreground)"
+                        : "var(--muted-foreground)",
+                    border:
+                      field.state.value === p
+                        ? "0.5px solid var(--primary)"
+                        : "0.5px solid transparent",
+                  }}
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
           </div>
         )}
       </form.Field>
 
-      <form.Field name="productName">
-        {(field) => (
-          <div className="flex flex-col gap-1">
-            <Label htmlFor="bean-product-name">製品名</Label>
-            <Input
-              id="bean-product-name"
+      {/* 標高 / 品種 */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+        <form.Field name="altitude">
+          {(field) => (
+            <TextInput
+              id="bean-altitude"
+              label="標高"
               value={field.state.value}
-              onChange={(e) => field.handleChange(e.target.value)}
+              onChange={field.handleChange}
+              placeholder="例: 1800m"
             />
-          </div>
-        )}
-      </form.Field>
+          )}
+        </form.Field>
+        <form.Field name="variety">
+          {(field) => (
+            <TextInput
+              id="bean-variety"
+              label="品種"
+              value={field.state.value}
+              onChange={field.handleChange}
+              placeholder="例: Heirloom"
+            />
+          )}
+        </form.Field>
+      </div>
 
-      <form.Field name="shopName">
-        {(field) => (
-          <div className="flex flex-col gap-1">
-            <Label htmlFor="bean-shop-name">購入店</Label>
-            <Input
+      {/* 購入先 / 購入日 */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+        <form.Field name="shopName">
+          {(field) => (
+            <TextInput
               id="bean-shop-name"
+              label="購入先"
               value={field.state.value}
-              onChange={(e) => field.handleChange(e.target.value)}
+              onChange={field.handleChange}
+              placeholder="例: Sweet Maria's"
             />
-          </div>
-        )}
-      </form.Field>
-
-      <form.Field name="purchasedAt">
-        {(field) => (
-          <div className="flex flex-col gap-1">
-            <Label htmlFor="bean-purchased-at">購入日</Label>
-            <Input
+          )}
+        </form.Field>
+        <form.Field name="purchasedAt">
+          {(field) => (
+            <TextInput
               id="bean-purchased-at"
-              type="date"
+              label="購入日"
               value={field.state.value}
-              onChange={(e) => field.handleChange(e.target.value)}
+              onChange={field.handleChange}
+              placeholder="2025-04-01"
             />
-          </div>
-        )}
-      </form.Field>
+          )}
+        </form.Field>
+      </div>
 
-      <form.Field name="importedAt">
-        {(field) => (
-          <div className="flex flex-col gap-1">
-            <Label htmlFor="bean-imported-at">輸入時期</Label>
-            <Input
-              id="bean-imported-at"
-              type="date"
-              value={field.state.value}
-              onChange={(e) => field.handleChange(e.target.value)}
-            />
-          </div>
-        )}
-      </form.Field>
-
-      <form.Field name="stockG">
-        {(field) => (
-          <div className="flex flex-col gap-1">
-            <Label htmlFor="bean-stock-g">在庫 (g)</Label>
-            <Input
-              id="bean-stock-g"
+      {/* 購入量 / 在庫 */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+        <form.Field name="totalG">
+          {(field) => (
+            <TextInput
+              id="bean-total-g"
+              label="購入量 (g)"
               type="number"
               value={field.state.value}
-              onChange={(e) => field.handleChange(Number(e.target.value))}
+              onChange={(v) => field.handleChange(Number(v))}
+              placeholder="400"
             />
-          </div>
-        )}
-      </form.Field>
+          )}
+        </form.Field>
+        <form.Field name="stockG">
+          {(field) => (
+            <TextInput
+              id="bean-stock-g"
+              label="在庫 (g)"
+              type="number"
+              value={field.state.value}
+              onChange={(v) => field.handleChange(Number(v))}
+              placeholder="400"
+            />
+          )}
+        </form.Field>
+      </div>
 
+      {/* フレーバータグ */}
+      {flavorTags.length > 0 && (
+        <form.Field name="flavorTagIds">
+          {(field) => (
+            <div>
+              <FieldLabel htmlFor="bean-flavor-tags">
+                フレーバーノート（任意）
+              </FieldLabel>
+              <div
+                id="bean-flavor-tags"
+                style={{ display: "flex", flexWrap: "wrap", gap: 6 }}
+              >
+                {flavorTags.map((tag) => {
+                  const selected = field.state.value.includes(tag.id);
+                  return (
+                    <button
+                      key={tag.id}
+                      type="button"
+                      onClick={() => {
+                        const next = selected
+                          ? field.state.value.filter((id) => id !== tag.id)
+                          : [...field.state.value, tag.id];
+                        field.handleChange(next);
+                      }}
+                      style={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 5,
+                        padding: "3px 10px",
+                        borderRadius: 999,
+                        fontSize: 12,
+                        fontWeight: 500,
+                        cursor: "pointer",
+                        background: selected
+                          ? `${tag.color}1A`
+                          : "var(--muted)",
+                        color: selected ? tag.color : "var(--muted-foreground)",
+                        border: selected
+                          ? `0.5px solid ${tag.color}66`
+                          : "0.5px solid var(--border)",
+                      }}
+                    >
+                      <span
+                        style={{
+                          width: 6,
+                          height: 6,
+                          borderRadius: "50%",
+                          background: selected
+                            ? tag.color
+                            : "var(--muted-foreground)",
+                        }}
+                      />
+                      {tag.name}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </form.Field>
+      )}
+
+      {/* メモ */}
       <form.Field name="note">
         {(field) => (
-          <div className="flex flex-col gap-1">
-            <Label htmlFor="bean-note">メモ</Label>
-            <Input
+          <div>
+            <FieldLabel htmlFor="bean-note">メモ</FieldLabel>
+            <textarea
               id="bean-note"
               value={field.state.value}
               onChange={(e) => field.handleChange(e.target.value)}
+              placeholder="香りや味わいの傾向など…"
+              rows={3}
+              style={{
+                width: "100%",
+                padding: "10px 12px",
+                background: "var(--muted)",
+                border: "0.5px solid var(--border)",
+                borderRadius: 8,
+                fontFamily: "Georgia, serif",
+                fontSize: 13,
+                lineHeight: 1.65,
+                color: "var(--foreground)",
+                resize: "none",
+                outline: "none",
+                boxSizing: "border-box",
+              }}
             />
           </div>
         )}
       </form.Field>
 
-      <Button type="submit">{submitLabel}</Button>
+      <button
+        type="submit"
+        style={{
+          width: "100%",
+          height: 52,
+          borderRadius: 10,
+          border: 0,
+          background: "var(--primary)",
+          color: "var(--primary-foreground)",
+          fontSize: 15,
+          fontWeight: 600,
+          cursor: "pointer",
+        }}
+      >
+        {submitLabel}
+      </button>
+
+      {onCancel && (
+        <button
+          type="button"
+          onClick={onCancel}
+          style={{
+            width: "100%",
+            height: 44,
+            borderRadius: 10,
+            border: "0.5px solid var(--border)",
+            background: "transparent",
+            color: "var(--muted-foreground)",
+            fontSize: 14,
+            fontWeight: 500,
+            cursor: "pointer",
+          }}
+        >
+          キャンセル
+        </button>
+      )}
     </form>
   );
 }

--- a/src/components/BeanForm.tsx
+++ b/src/components/BeanForm.tsx
@@ -12,9 +12,9 @@ const FormSchema = z.object({
   shopName: z.string(),
   purchasedAt: z.string(),
   importedAt: z.string(),
-  stockG: z.number(),
+  stockG: z.number().nonnegative("在庫は 0 以上で入力してください"),
   note: z.string(),
-  totalG: z.number(),
+  totalG: z.number().nonnegative("購入量は 0 以上で入力してください"),
   flavorTagIds: z.array(z.string()),
   process: z.string(),
   region: z.string(),
@@ -217,13 +217,23 @@ export function BeanForm({
       {/* 精製方法 */}
       <form.Field name="process">
         {(field) => (
-          <div>
-            <FieldLabel htmlFor="bean-process">精製方法</FieldLabel>
+          <fieldset style={{ border: 0, padding: 0, margin: 0 }}>
+            <legend
+              style={{
+                fontSize: 12,
+                fontWeight: 500,
+                color: "var(--muted-foreground)",
+                marginBottom: 6,
+              }}
+            >
+              精製方法
+            </legend>
             <div style={{ display: "flex", gap: 6 }}>
               {PROCESSES.map((p) => (
                 <button
                   key={p}
                   type="button"
+                  aria-pressed={field.state.value === p}
                   onClick={() => field.handleChange(p)}
                   style={{
                     flex: 1,
@@ -250,7 +260,7 @@ export function BeanForm({
                 </button>
               ))}
             </div>
-          </div>
+          </fieldset>
         )}
       </form.Field>
 
@@ -338,20 +348,25 @@ export function BeanForm({
       {flavorTags.length > 0 && (
         <form.Field name="flavorTagIds">
           {(field) => (
-            <div>
-              <FieldLabel htmlFor="bean-flavor-tags">
-                フレーバーノート（任意）
-              </FieldLabel>
-              <div
-                id="bean-flavor-tags"
-                style={{ display: "flex", flexWrap: "wrap", gap: 6 }}
+            <fieldset style={{ border: 0, padding: 0, margin: 0 }}>
+              <legend
+                style={{
+                  fontSize: 12,
+                  fontWeight: 500,
+                  color: "var(--muted-foreground)",
+                  marginBottom: 6,
+                }}
               >
+                フレーバーノート（任意）
+              </legend>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
                 {flavorTags.map((tag) => {
                   const selected = field.state.value.includes(tag.id);
                   return (
                     <button
                       key={tag.id}
                       type="button"
+                      aria-pressed={selected}
                       onClick={() => {
                         const next = selected
                           ? field.state.value.filter((id) => id !== tag.id)
@@ -391,7 +406,7 @@ export function BeanForm({
                   );
                 })}
               </div>
-            </div>
+            </fieldset>
           )}
         </form.Field>
       )}

--- a/src/components/BeanListPage.test.tsx
+++ b/src/components/BeanListPage.test.tsx
@@ -62,7 +62,7 @@ describe("BeanListPage", () => {
   it("生豆が 0 件のとき空状態メッセージが表示される", async () => {
     renderPage();
     await waitFor(() =>
-      expect(screen.getByText("生豆が登録されていません")).toBeInTheDocument(),
+      expect(screen.getByText("豆がありません")).toBeInTheDocument(),
     );
   });
 
@@ -78,24 +78,30 @@ describe("BeanListPage", () => {
       stockG: 500,
       bestLogId: null,
       note: "",
+      totalG: 0,
+      flavorTagIds: [],
+      process: "",
+      region: "",
+      altitude: "",
+      variety: "",
     });
 
     renderPage();
     await waitFor(() =>
       expect(screen.getByText("エチオピア イルガチェフェ")).toBeInTheDocument(),
     );
-    expect(screen.getByText(/エチオピア$/)).toBeInTheDocument();
-    expect(screen.getByText("在庫: 500g")).toBeInTheDocument();
+    expect(screen.getByText("エチオピア")).toBeInTheDocument();
+    expect(screen.getByText(/残 100%/)).toBeInTheDocument();
   });
 
-  it("「生豆を追加」ボタンで /beans/new へ遷移する", async () => {
+  it("「豆を追加」ボタンで /beans/new へ遷移する", async () => {
     const user = userEvent.setup();
     const router = renderPage();
     await waitFor(() =>
-      expect(screen.getByText("生豆が登録されていません")).toBeInTheDocument(),
+      expect(screen.getByText("豆がありません")).toBeInTheDocument(),
     );
 
-    await user.click(screen.getByRole("link", { name: "生豆を追加" }));
+    await user.click(screen.getByRole("button", { name: "豆を追加" }));
 
     await waitFor(() =>
       expect(router.state.location.pathname).toBe("/beans/new"),
@@ -115,6 +121,12 @@ describe("BeanListPage", () => {
       stockG: 200,
       bestLogId: null,
       note: "",
+      totalG: 0,
+      flavorTagIds: [],
+      process: "",
+      region: "",
+      altitude: "",
+      variety: "",
     });
 
     const user = userEvent.setup();
@@ -123,10 +135,37 @@ describe("BeanListPage", () => {
       expect(screen.getByText("ブラジル セラード")).toBeInTheDocument(),
     );
 
-    await user.click(screen.getByRole("link", { name: /ブラジル セラード/ }));
+    await user.click(screen.getByRole("button", { name: /ブラジル セラード/ }));
 
     await waitFor(() =>
       expect(router.state.location.pathname).toBe(`/beans/${id}`),
     );
+  });
+
+  it("在庫切れ豆にバッジが表示される", async () => {
+    await db.beans.put({
+      id: crypto.randomUUID(),
+      name: "ケニア ニエリ",
+      origin: "ケニア",
+      productName: "",
+      shopName: "",
+      purchasedAt: null,
+      importedAt: null,
+      stockG: 0,
+      bestLogId: null,
+      note: "",
+      totalG: 300,
+      flavorTagIds: [],
+      process: "",
+      region: "",
+      altitude: "",
+      variety: "",
+    });
+
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("ケニア ニエリ")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("在庫切れ")).toBeInTheDocument();
   });
 });

--- a/src/components/BeanListPage.tsx
+++ b/src/components/BeanListPage.tsx
@@ -254,6 +254,7 @@ export function BeanListPage() {
             <input
               ref={inputRef}
               type="text"
+              aria-label="豆を検索"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="豆を検索…"

--- a/src/components/BeanListPage.tsx
+++ b/src/components/BeanListPage.tsx
@@ -1,44 +1,587 @@
-import { Link } from "@tanstack/react-router";
-import { buttonVariants } from "@/components/ui/button";
+import { useNavigate } from "@tanstack/react-router";
+import { useRef, useState } from "react";
 import { useBeans } from "@/hooks/useBeans";
+import { useFlavorTags } from "@/hooks/useFlavorTags";
+import { useRoastLogs } from "@/hooks/useRoastLogs";
+import type { Bean } from "@/schemas/bean";
+
+function stockPct(bean: Bean): number {
+  if (bean.totalG > 0) return (bean.stockG / bean.totalG) * 100;
+  return bean.stockG > 0 ? 100 : 0;
+}
+
+function StockBar({ pct }: { pct: number }) {
+  let color = "#2D7D52";
+  if (pct === 0) color = "var(--border)";
+  else if (pct < 20) color = "#B83232";
+  else if (pct < 50) color = "#D4943A";
+  return (
+    <div
+      style={{
+        height: 4,
+        background: "var(--border)",
+        borderRadius: 2,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          height: "100%",
+          width: `${Math.max(0, Math.min(100, pct))}%`,
+          background: color,
+          borderRadius: 2,
+          transition: "width 320ms ease",
+        }}
+      />
+    </div>
+  );
+}
+
+function StockBadge({ pct }: { pct: number }) {
+  if (pct === 0)
+    return (
+      <span
+        style={{
+          fontSize: 10,
+          fontWeight: 500,
+          padding: "2px 7px",
+          borderRadius: 999,
+          background: "var(--muted)",
+          color: "var(--muted-foreground)",
+          border: "0.5px solid var(--border)",
+        }}
+      >
+        在庫切れ
+      </span>
+    );
+  if (pct < 20)
+    return (
+      <span
+        style={{
+          fontSize: 10,
+          fontWeight: 500,
+          padding: "2px 7px",
+          borderRadius: 999,
+          background: "#FDEAEA",
+          color: "#B83232",
+          border: "0.5px solid #B8323233",
+        }}
+      >
+        残りわずか
+      </span>
+    );
+  return null;
+}
+
+type StockFilter = "all" | "instock" | "low" | "out";
 
 export function BeanListPage() {
-  const { data: beans, isLoading } = useBeans();
+  const navigate = useNavigate();
+  const [search, setSearch] = useState("");
+  const [showSearch, setShowSearch] = useState(false);
+  const [filterStock, setFilterStock] = useState<StockFilter>("all");
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  if (isLoading) return null;
+  const { data: beans = [], isLoading: beansLoading } = useBeans();
+  const { data: logs = [], isLoading: logsLoading } = useRoastLogs();
+  const { data: flavorTags = [], isLoading: tagsLoading } = useFlavorTags();
+
+  if (beansLoading || logsLoading || tagsLoading) return null;
+
+  const tagMap = Object.fromEntries(flavorTags.map((t) => [t.id, t]));
+  const roastCountMap = logs.reduce<Record<string, number>>((acc, l) => {
+    acc[l.beanId] = (acc[l.beanId] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const totalBeans = beans.length;
+  const lowStockCount = beans.filter((b) => {
+    const p = stockPct(b);
+    return p > 0 && p < 20;
+  }).length;
+  const outStockCount = beans.filter((b) => stockPct(b) === 0).length;
+
+  const filtered = beans.filter((b) => {
+    const q = search.toLowerCase();
+    const matchSearch =
+      !q ||
+      b.name.toLowerCase().includes(q) ||
+      b.origin.toLowerCase().includes(q);
+    const pct = stockPct(b);
+    const matchStock =
+      filterStock === "all"
+        ? true
+        : filterStock === "instock"
+          ? pct >= 20
+          : filterStock === "low"
+            ? pct > 0 && pct < 20
+            : filterStock === "out"
+              ? pct === 0
+              : true;
+    return matchSearch && matchStock;
+  });
+
+  function chipStyle(
+    id: StockFilter,
+    warn = false,
+    danger = false,
+  ): React.CSSProperties {
+    const active = filterStock === id;
+    let bg = active ? "var(--foreground)" : "var(--card)";
+    let color = active ? "#fff" : "var(--muted-foreground)";
+    if (!active && warn && lowStockCount > 0) {
+      bg = "#FFF8E8";
+      color = "#D4943A";
+    }
+    if (!active && danger && outStockCount > 0) {
+      bg = "#FDEAEA";
+      color = "#B83232";
+    }
+    return {
+      padding: "5px 10px",
+      borderRadius: 999,
+      fontSize: 11,
+      whiteSpace: "nowrap",
+      fontWeight: 500,
+      cursor: "pointer",
+      background: bg,
+      color,
+      border: `0.5px solid ${active ? "var(--foreground)" : "var(--border)"}`,
+      flexShrink: 0,
+    };
+  }
 
   return (
-    <div className="h-full overflow-y-auto p-6">
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-2xl font-bold">生豆</h1>
-        <Link to="/beans/new" className={buttonVariants()}>
-          生豆を追加
-        </Link>
+    <div
+      style={{
+        position: "relative",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+      }}
+    >
+      {/* Header */}
+      <header
+        style={{
+          flexShrink: 0,
+          height: 52,
+          display: "flex",
+          alignItems: "center",
+          padding: "0 8px",
+          background: "var(--background)",
+          borderBottom: "0.5px solid var(--border)",
+        }}
+      >
+        <div style={{ width: 44 }} />
+        <div
+          style={{
+            flex: 1,
+            textAlign: "center",
+            fontWeight: 500,
+            fontSize: 18,
+            color: "var(--foreground)",
+          }}
+        >
+          豆
+        </div>
+        <button
+          type="button"
+          aria-label="検索"
+          aria-pressed={showSearch}
+          onClick={() => {
+            setShowSearch((s) => !s);
+            setTimeout(() => inputRef.current?.focus(), 50);
+          }}
+          style={{
+            width: 44,
+            height: 44,
+            background: "transparent",
+            border: 0,
+            color: showSearch ? "var(--primary)" : "var(--foreground)",
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <svg
+            aria-hidden="true"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="M21 21l-4.3-4.3" />
+          </svg>
+        </button>
+      </header>
+
+      {/* Search bar */}
+      {showSearch && (
+        <div style={{ padding: "8px 16px 4px", flexShrink: 0 }}>
+          <div
+            style={{
+              height: 40,
+              padding: "0 12px",
+              background: "var(--muted)",
+              border: "0.5px solid var(--border)",
+              borderRadius: 8,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <svg
+              aria-hidden="true"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="var(--muted-foreground)"
+              strokeWidth="1.75"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path d="M21 21l-4.3-4.3" />
+            </svg>
+            <input
+              ref={inputRef}
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="豆を検索…"
+              style={{
+                flex: 1,
+                background: "transparent",
+                border: 0,
+                outline: "none",
+                fontSize: 14,
+                color: "var(--foreground)",
+              }}
+            />
+            {search && (
+              <button
+                type="button"
+                onClick={() => setSearch("")}
+                aria-label="検索をクリア"
+                style={{
+                  background: "transparent",
+                  border: 0,
+                  padding: 0,
+                  cursor: "pointer",
+                  color: "var(--muted-foreground)",
+                  display: "flex",
+                }}
+              >
+                <svg
+                  aria-hidden="true"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.75"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Filter chips */}
+      <div
+        style={{
+          flexShrink: 0,
+          padding: "8px 16px 10px",
+          display: "flex",
+          gap: 6,
+          overflowX: "auto",
+          scrollbarWidth: "none",
+        }}
+      >
+        <button
+          type="button"
+          style={chipStyle("all")}
+          onClick={() => setFilterStock("all")}
+        >
+          すべて {totalBeans}
+        </button>
+        <button
+          type="button"
+          style={chipStyle("instock")}
+          onClick={() => setFilterStock("instock")}
+        >
+          在庫あり
+        </button>
+        <button
+          type="button"
+          style={chipStyle("low", true)}
+          onClick={() => setFilterStock("low")}
+        >
+          残りわずか{lowStockCount > 0 ? ` ${lowStockCount}` : ""}
+        </button>
+        <button
+          type="button"
+          style={chipStyle("out", false, true)}
+          onClick={() => setFilterStock("out")}
+        >
+          在庫切れ{outStockCount > 0 ? ` ${outStockCount}` : ""}
+        </button>
       </div>
 
-      {beans?.length === 0 ? (
-        <p className="text-muted-foreground">生豆が登録されていません</p>
-      ) : (
-        <ul className="flex flex-col gap-2">
-          {beans?.map((bean) => (
-            <li key={bean.id}>
-              <Link
-                to="/beans/$beanId"
-                params={{ beanId: bean.id }}
-                className="block p-4 border rounded-lg hover:bg-accent"
+      {/* Bean list */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: "auto",
+          padding: "0 16px 100px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+        }}
+      >
+        {filtered.length === 0 ? (
+          <p
+            style={{
+              paddingTop: 64,
+              textAlign: "center",
+              fontSize: 13,
+              color: "var(--muted-foreground)",
+            }}
+          >
+            {search
+              ? `「${search}」に一致する豆がありません`
+              : "豆がありません"}
+          </p>
+        ) : (
+          filtered.map((bean) => {
+            const pct = stockPct(bean);
+            const count = roastCountMap[bean.id] ?? 0;
+            return (
+              <button
+                type="button"
+                key={bean.id}
+                onClick={() =>
+                  navigate({
+                    to: "/beans/$beanId",
+                    params: { beanId: bean.id },
+                  })
+                }
+                style={{
+                  background: "var(--card)",
+                  border: "0.5px solid var(--border)",
+                  borderRadius: 10,
+                  padding: 12,
+                  boxShadow:
+                    "0 1px 2px rgba(28,23,20,0.04), 0 1px 1px rgba(28,23,20,0.03)",
+                  cursor: "pointer",
+                  textAlign: "left",
+                  width: "100%",
+                }}
               >
-                <p className="font-medium">{bean.name}</p>
-                {bean.origin && (
-                  <p className="text-sm text-muted-foreground">{bean.origin}</p>
-                )}
-                <p className="text-sm text-muted-foreground">
-                  在庫: {bean.stockG}g
-                </p>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
+                {/* Top row */}
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div
+                      style={{
+                        fontFamily: "Georgia, serif",
+                        fontSize: 16,
+                        fontWeight: 500,
+                        lineHeight: 1.3,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {bean.name}
+                    </div>
+                    <div
+                      style={{
+                        fontSize: 11,
+                        color: "var(--muted-foreground)",
+                        marginTop: 2,
+                      }}
+                    >
+                      {bean.origin}
+                      {bean.process ? ` · ${bean.process}` : ""}
+                    </div>
+                  </div>
+                  <div
+                    style={{
+                      textAlign: "right",
+                      flexShrink: 0,
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "flex-end",
+                      gap: 3,
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontFamily: "Georgia, serif",
+                        fontSize: 18,
+                        fontWeight: 500,
+                        fontVariantNumeric: "tabular-nums",
+                        lineHeight: 1,
+                      }}
+                    >
+                      {bean.stockG}
+                      <span
+                        style={{
+                          fontSize: 11,
+                          color: "var(--muted-foreground)",
+                          marginLeft: 2,
+                          fontWeight: 400,
+                        }}
+                      >
+                        g
+                      </span>
+                    </div>
+                    <StockBadge pct={pct} />
+                  </div>
+                </div>
+
+                {/* Stock bar */}
+                <div style={{ marginTop: 10 }}>
+                  <StockBar pct={pct} />
+                </div>
+
+                {/* Bottom meta */}
+                <div
+                  style={{
+                    marginTop: 8,
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontFamily: "ui-monospace, monospace",
+                      fontSize: 10,
+                      color: "var(--muted-foreground)",
+                    }}
+                  >
+                    残 {Math.round(pct)}% ·{" "}
+                    {count > 0 ? `${count}回焙煎` : "未焙煎"}
+                  </span>
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: 4,
+                      flexWrap: "wrap",
+                      justifyContent: "flex-end",
+                    }}
+                  >
+                    {bean.flavorTagIds.slice(0, 3).map((tid) => {
+                      const tag = tagMap[tid];
+                      if (!tag) return null;
+                      return (
+                        <span
+                          key={tid}
+                          style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            gap: 4,
+                            padding: "2px 7px",
+                            borderRadius: 999,
+                            fontSize: 10,
+                            fontWeight: 500,
+                            background: `${tag.color}1A`,
+                            color: tag.color,
+                            border: `0.5px solid ${tag.color}33`,
+                          }}
+                        >
+                          <span
+                            style={{
+                              width: 5,
+                              height: 5,
+                              borderRadius: "50%",
+                              background: tag.color,
+                            }}
+                          />
+                          {tag.name}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
+              </button>
+            );
+          })
+        )}
+      </div>
+
+      {/* FAB */}
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          padding: "12px 16px 14px",
+          background:
+            "linear-gradient(to top, var(--background) 60%, transparent)",
+          pointerEvents: "none",
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => navigate({ to: "/beans/new" })}
+          style={{
+            pointerEvents: "auto",
+            width: "100%",
+            height: 52,
+            borderRadius: 10,
+            border: 0,
+            background: "var(--primary)",
+            color: "var(--primary-foreground)",
+            fontSize: 15,
+            fontWeight: 600,
+            cursor: "pointer",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 8,
+            boxShadow:
+              "0 4px 12px rgba(176,107,30,0.28), 0 2px 4px rgba(28,23,20,0.08)",
+          }}
+        >
+          <svg
+            aria-hidden="true"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12 5v14M5 12h14" />
+          </svg>
+          豆を追加
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/RoastLogCreatePage.test.tsx
+++ b/src/components/RoastLogCreatePage.test.tsx
@@ -26,6 +26,12 @@ const BEAN: Bean = {
   stockG: 500,
   bestLogId: null,
   note: "",
+  totalG: 0,
+  flavorTagIds: [],
+  process: "",
+  region: "",
+  altitude: "",
+  variety: "",
 };
 
 const LEVEL: RoastLevel = {

--- a/src/components/RoastLogDetailPage.test.tsx
+++ b/src/components/RoastLogDetailPage.test.tsx
@@ -27,6 +27,12 @@ const BEAN: Bean = {
   stockG: 500,
   bestLogId: null,
   note: "",
+  totalG: 0,
+  flavorTagIds: [],
+  process: "",
+  region: "",
+  altitude: "",
+  variety: "",
 };
 
 const LEVEL: RoastLevel = {

--- a/src/components/RoastLogEditPage.test.tsx
+++ b/src/components/RoastLogEditPage.test.tsx
@@ -27,6 +27,12 @@ const BEAN: Bean = {
   stockG: 500,
   bestLogId: null,
   note: "",
+  totalG: 0,
+  flavorTagIds: [],
+  process: "",
+  region: "",
+  altitude: "",
+  variety: "",
 };
 
 const LEVEL: RoastLevel = {

--- a/src/components/RoastLogForm.test.tsx
+++ b/src/components/RoastLogForm.test.tsx
@@ -17,6 +17,12 @@ const BEAN: Bean = {
   stockG: 500,
   bestLogId: null,
   note: "",
+  totalG: 0,
+  flavorTagIds: [],
+  process: "",
+  region: "",
+  altitude: "",
+  variety: "",
 };
 
 const LEVEL: RoastLevel = {

--- a/src/components/RoastLogListPage.test.tsx
+++ b/src/components/RoastLogListPage.test.tsx
@@ -30,6 +30,12 @@ const SAMPLE_BEAN: Bean = {
   stockG: 500,
   bestLogId: null,
   note: "",
+  totalG: 0,
+  flavorTagIds: [],
+  process: "",
+  region: "",
+  altitude: "",
+  variety: "",
 };
 
 const SAMPLE_LEVEL: RoastLevel = {

--- a/src/hooks/useBeans.test.tsx
+++ b/src/hooks/useBeans.test.tsx
@@ -57,6 +57,12 @@ describe("useBeans", () => {
         importedAt: null,
         stockG: 500,
         note: "",
+        totalG: 0,
+        flavorTagIds: [],
+        process: "",
+        region: "",
+        altitude: "",
+        variety: "",
       });
     });
 
@@ -83,6 +89,12 @@ describe("useBeans", () => {
         importedAt: null,
         stockG: 300,
         note: "",
+        totalG: 0,
+        flavorTagIds: [],
+        process: "",
+        region: "",
+        altitude: "",
+        variety: "",
       });
     });
     await waitFor(() => expect(beans.current.data).toHaveLength(1));
@@ -112,6 +124,12 @@ describe("useBeans", () => {
         importedAt: null,
         stockG: 400,
         note: "",
+        totalG: 0,
+        flavorTagIds: [],
+        process: "",
+        region: "",
+        altitude: "",
+        variety: "",
       });
     });
     await waitFor(() => expect(beans.current.data).toHaveLength(1));
@@ -149,6 +167,12 @@ describe("useBeans", () => {
         importedAt: null,
         stockG: 200,
         note: "",
+        totalG: 0,
+        flavorTagIds: [],
+        process: "",
+        region: "",
+        altitude: "",
+        variety: "",
       });
     });
     await waitFor(() => expect(beans.current.data).toHaveLength(1));

--- a/src/hooks/useMutateBean.ts
+++ b/src/hooks/useMutateBean.ts
@@ -2,7 +2,6 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { db } from "@/db";
 import { BeanRepository } from "@/repositories/beanRepository";
 import type { Bean, CreateBeanInput } from "@/schemas/bean";
-import { BeanSchema } from "@/schemas/bean";
 
 const repo = new BeanRepository(db.beans);
 
@@ -10,11 +9,17 @@ export function useCreateBean() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (input: CreateBeanInput): Promise<Bean> => {
-      const bean = BeanSchema.parse({
+      const bean: Bean = {
         ...input,
         id: crypto.randomUUID(),
         bestLogId: null,
-      });
+        totalG: input.totalG ?? 0,
+        flavorTagIds: input.flavorTagIds ?? [],
+        process: input.process ?? "",
+        region: input.region ?? "",
+        altitude: input.altitude ?? "",
+        variety: input.variety ?? "",
+      };
       await repo.save(bean);
       return bean;
     },

--- a/src/hooks/useMutateBean.ts
+++ b/src/hooks/useMutateBean.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { db } from "@/db";
 import { BeanRepository } from "@/repositories/beanRepository";
 import type { Bean, CreateBeanInput } from "@/schemas/bean";
+import { BeanSchema } from "@/schemas/bean";
 
 const repo = new BeanRepository(db.beans);
 
@@ -9,11 +10,11 @@ export function useCreateBean() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (input: CreateBeanInput): Promise<Bean> => {
-      const bean: Bean = {
+      const bean = BeanSchema.parse({
         ...input,
         id: crypto.randomUUID(),
         bestLogId: null,
-      };
+      });
       await repo.save(bean);
       return bean;
     },

--- a/src/hooks/useRoastLogs.test.tsx
+++ b/src/hooks/useRoastLogs.test.tsx
@@ -70,6 +70,12 @@ describe("useRoastLogs", () => {
       stockG: 500,
       bestLogId: null,
       note: "",
+      totalG: 0,
+      flavorTagIds: [],
+      process: "",
+      region: "",
+      altitude: "",
+      variety: "",
     });
 
     const qc = makeQc();
@@ -101,6 +107,12 @@ describe("useRoastLogs", () => {
       stockG: 500,
       bestLogId: null,
       note: "",
+      totalG: 0,
+      flavorTagIds: [],
+      process: "",
+      region: "",
+      altitude: "",
+      variety: "",
     });
 
     const qc = makeQc();
@@ -130,6 +142,12 @@ describe("useRoastLogs", () => {
       stockG: 500,
       bestLogId: null,
       note: "",
+      totalG: 0,
+      flavorTagIds: [],
+      process: "",
+      region: "",
+      altitude: "",
+      variety: "",
     });
 
     const qc = makeQc();

--- a/src/repositories/beanRepository.test.ts
+++ b/src/repositories/beanRepository.test.ts
@@ -28,6 +28,12 @@ const makeBean = (overrides: Partial<Bean> = {}): Bean => ({
   stockG: 500,
   bestLogId: null,
   note: "",
+  totalG: 0,
+  flavorTagIds: [],
+  process: "",
+  region: "",
+  altitude: "",
+  variety: "",
   ...overrides,
 });
 

--- a/src/schemas/bean.ts
+++ b/src/schemas/bean.ts
@@ -11,6 +11,12 @@ export const BeanSchema = z.object({
   stockG: z.number(),
   bestLogId: z.string().uuid().nullable(),
   note: z.string(),
+  totalG: z.number().optional().default(0),
+  flavorTagIds: z.array(z.string()).optional().default([]),
+  process: z.string().optional().default(""),
+  region: z.string().optional().default(""),
+  altitude: z.string().optional().default(""),
+  variety: z.string().optional().default(""),
 });
 
 export type Bean = z.infer<typeof BeanSchema>;


### PR DESCRIPTION
## Summary

- `BeanSchema` に 6 フィールド追加（`totalG` / `flavorTagIds` / `process` / `region` / `altitude` / `variety`）。`optional().default()` で既存レコードと後方互換。
- **BeanListPage** を全面刷新：検索バー・在庫フィルターチップ（すべて/在庫あり/残りわずか/在庫切れ）・在庫バー・フレーバータグピル・FAB
- **BeanDetailPage** を全面刷新：スペックグリッド・焙煎履歴（RoastBadge / StarRating / ベストバッジ）・在庫更新シート（増減/直接入力モード）
- **BeanForm** を全面刷新：精製方法トグル・フレーバータグ多択ピッカー・新フィールド対応
- **BeanCreatePage / BeanEditPage** を新フィールドに対応
- `useMutateBean`: `BeanSchema.parse()` でデフォルト値を補完
- RoastLog 系・フック系テストの Bean フィクスチャを新スキーマに更新

## Test plan

- [ ] `npm run test:unit` → 41 passed
- [ ] `npm run test:browser` → 105 passed
- [ ] `npx tsc --noEmit` → エラーなし
- [ ] `npm run lint:fix` → エラーなし（警告のみ）
- [ ] `npm run arch:check` → 依存関係違反なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新内容

* **新機能**
  * 豆の在庫更新機能を追加しました。
  * 豆一覧に検索機能と在庫フィルター機能を追加しました。
  * 豆の詳細表示に焙煎履歴一覧を追加しました。
  * 在庫量を視覚的に表示するストックバーを追加しました。
  * 豆の精製方法とフレーバータグの選択機能を追加しました。

* **改善**
  * 豆の作成・編集・詳細表示ページのレイアウトを刷新しました。
  * 在庫切れバッジなど、豆のステータスを視覚的に改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->