### PR TITLE
feat(slice-5): Tasting 評価 + Cleanliness 警告

### DIFF
--- a/src/components/RoastLogCreatePage.test.tsx
+++ b/src/components/RoastLogCreatePage.test.tsx
@@ -107,9 +107,9 @@ describe("RoastLogCreatePage", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "登録" }));
 
-    await waitFor(() =>
-      expect(router.state.location.pathname).toMatch(/^\/logs\/.+$/),
-    );
-    expect(screen.getByText("詳細ページ")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(router.state.location.pathname).toMatch(/^\/logs\/.+$/);
+      expect(screen.getByText("詳細ページ")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/RoastLogCreatePage.tsx
+++ b/src/components/RoastLogCreatePage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "@tanstack/react-router";
 import { RoastLogForm } from "@/components/RoastLogForm";
 import { useBeans } from "@/hooks/useBeans";
+import { useFlavorTags } from "@/hooks/useFlavorTags";
 import { useCreateRoastLog } from "@/hooks/useMutateRoastLog";
 import { useRoastDevices } from "@/hooks/useRoastDevices";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
@@ -32,8 +33,11 @@ export function RoastLogCreatePage() {
   const { data: beans = [], isLoading: beansLoading } = useBeans();
   const { data: levels = [], isLoading: levelsLoading } = useRoastLevels();
   const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
+  const { data: flavorTags = [], isLoading: flavorTagsLoading } =
+    useFlavorTags();
 
-  if (beansLoading || levelsLoading || devicesLoading) return null;
+  if (beansLoading || levelsLoading || devicesLoading || flavorTagsLoading)
+    return null;
 
   const today = new Date();
   const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
@@ -53,6 +57,7 @@ export function RoastLogCreatePage() {
         beans={beans}
         roastLevels={levels}
         roastDevices={devices}
+        flavorTags={flavorTags}
         submitLabel="登録"
         onSubmit={async (input: CreateRoastLogInput) => {
           const log = await mutateAsync(input);

--- a/src/components/RoastLogDetailPage.test.tsx
+++ b/src/components/RoastLogDetailPage.test.tsx
@@ -13,7 +13,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { RoastLogDetailPage } from "@/components/RoastLogDetailPage";
 import { db } from "@/db";
 import type { Bean } from "@/schemas/bean";
-import type { RoastDevice, RoastLevel } from "@/schemas/masterData";
+import type { FlavorTag, RoastDevice, RoastLevel } from "@/schemas/masterData";
 import type { RoastLog } from "@/schemas/roastLog";
 
 const BEAN: Bean = {
@@ -47,6 +47,12 @@ const DEVICE: RoastDevice = {
   name: "手網",
   method: "",
   note: "",
+};
+
+const FLAVOR_TAG: FlavorTag = {
+  id: "tag-floral",
+  name: "フローラル",
+  color: "#F472B6",
 };
 
 const LOG: RoastLog = {
@@ -161,6 +167,55 @@ describe("RoastLogDetailPage", () => {
       expect(router.state.location.pathname).toMatch(/\/edit$/),
     );
     expect(screen.getByText("編集ページ")).toBeInTheDocument();
+  });
+
+  it("tasting がある場合に 6 軸スコアとフレーバータグを表示する", async () => {
+    const logWithTasting: RoastLog = {
+      ...LOG,
+      tasting: {
+        flavorTags: [FLAVOR_TAG.id],
+        sweetness: 4,
+        acidity: 3,
+        body: 3,
+        bitterness: 2,
+        aftertaste: 4,
+        cleanliness: 5,
+      },
+      overallScore: 4,
+    };
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastDevices.put(DEVICE);
+    await db.flavorTags.put(FLAVOR_TAG);
+    await db.roastLogs.put(logWithTasting);
+
+    renderDetailPage(LOG.id);
+
+    await waitFor(() =>
+      expect(screen.getByText("テイスティング")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("フローラル")).toBeInTheDocument();
+    expect(screen.getByText("甘さ")).toBeInTheDocument();
+    expect(screen.getByText("酸味")).toBeInTheDocument();
+    expect(screen.getByText("コク")).toBeInTheDocument();
+    expect(screen.getByText("苦み")).toBeInTheDocument();
+    expect(screen.getByText("後味")).toBeInTheDocument();
+    expect(screen.getByText("クリーン")).toBeInTheDocument();
+    expect(screen.getByText("総合評価")).toBeInTheDocument();
+  });
+
+  it("tasting が null のとき「テイスティング」セクションを表示しない", async () => {
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastDevices.put(DEVICE);
+    await db.roastLogs.put(LOG);
+
+    renderDetailPage(LOG.id);
+
+    await waitFor(() =>
+      expect(screen.getByText("エチオピア イルガチェフェ")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("テイスティング")).not.toBeInTheDocument();
   });
 
   it("「削除」ボタンでログを削除し一覧へ遷移する", async () => {

--- a/src/components/RoastLogDetailPage.tsx
+++ b/src/components/RoastLogDetailPage.tsx
@@ -1,6 +1,8 @@
 import { useNavigate } from "@tanstack/react-router";
+import { StarRating } from "@/components/StarRating";
 import { calcWeightLossRate } from "@/domain/roastLog";
 import { useBeans } from "@/hooks/useBeans";
+import { useFlavorTags } from "@/hooks/useFlavorTags";
 import { useDeleteRoastLog } from "@/hooks/useMutateRoastLog";
 import { useRoastDevices } from "@/hooks/useRoastDevices";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
@@ -23,9 +25,17 @@ export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
   const { data: beans = [], isLoading: beansLoading } = useBeans();
   const { data: levels = [], isLoading: levelsLoading } = useRoastLevels();
   const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
+  const { data: flavorTags = [], isLoading: flavorTagsLoading } =
+    useFlavorTags();
   const { mutateAsync: deleteLog } = useDeleteRoastLog();
 
-  if (logLoading || beansLoading || levelsLoading || devicesLoading)
+  if (
+    logLoading ||
+    beansLoading ||
+    levelsLoading ||
+    devicesLoading ||
+    flavorTagsLoading
+  )
     return null;
   if (!log) return <p>ログが見つかりません</p>;
 
@@ -33,6 +43,8 @@ export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
   const level = levels.find((l) => l.id === log.roastLevelId);
   const device = devices.find((d) => d.id === log.roastDeviceId);
   const rate = calcWeightLossRate(log.weightBeforeG, log.weightAfterG);
+  const flavorTagMap = Object.fromEntries(flavorTags.map((t) => [t.id, t]));
+  const tasting = log.tasting;
 
   const handleDelete = async () => {
     await deleteLog(logId);
@@ -101,6 +113,67 @@ export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
         <div>
           <p className="text-sm text-muted-foreground mb-1">焙煎メモ</p>
           <p className="text-sm">{log.processNote}</p>
+        </div>
+      )}
+
+      {/* 総合評価 */}
+      {log.overallScore != null && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">総合評価</p>
+          <StarRating value={log.overallScore} size={18} />
+        </div>
+      )}
+
+      {/* テイスティング */}
+      {tasting && (
+        <div className="border-t pt-4 flex flex-col gap-3">
+          <p className="text-sm font-medium">テイスティング</p>
+
+          {tasting.flavorTags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {tasting.flavorTags.map((tagId) => {
+                const tag = flavorTagMap[tagId];
+                if (!tag) return null;
+                return (
+                  <span
+                    key={tagId}
+                    className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium"
+                    style={{
+                      background: `${tag.color}1A`,
+                      color: tag.color,
+                      border: `0.5px solid ${tag.color}66`,
+                    }}
+                  >
+                    <span
+                      className="w-1.5 h-1.5 rounded-full"
+                      style={{ background: tag.color }}
+                    />
+                    {tag.name}
+                  </span>
+                );
+              })}
+            </div>
+          )}
+
+          <dl className="flex flex-col gap-2">
+            {(
+              [
+                { key: "sweetness", label: "甘さ" },
+                { key: "acidity", label: "酸味" },
+                { key: "body", label: "コク" },
+                { key: "bitterness", label: "苦み" },
+                { key: "aftertaste", label: "後味" },
+                { key: "cleanliness", label: "クリーン" },
+              ] as const
+            ).map(({ key, label }) => (
+              <div key={key} className="flex items-center justify-between">
+                <dt className="text-sm text-muted-foreground">{label}</dt>
+                <dd>
+                  <StarRating value={tasting[key]} size={14} />
+                </dd>
+              </div>
+            ))}
+          </dl>
         </div>
       )}
     </div>

--- a/src/components/RoastLogEditPage.tsx
+++ b/src/components/RoastLogEditPage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "@tanstack/react-router";
 import { RoastLogForm } from "@/components/RoastLogForm";
 import { useBeans } from "@/hooks/useBeans";
+import { useFlavorTags } from "@/hooks/useFlavorTags";
 import { useUpdateRoastLog } from "@/hooks/useMutateRoastLog";
 import { useRoastDevices } from "@/hooks/useRoastDevices";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
@@ -17,9 +18,17 @@ export function RoastLogEditPage({ logId }: RoastLogEditPageProps) {
   const { data: beans = [], isLoading: beansLoading } = useBeans();
   const { data: levels = [], isLoading: levelsLoading } = useRoastLevels();
   const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
+  const { data: flavorTags = [], isLoading: flavorTagsLoading } =
+    useFlavorTags();
   const { mutateAsync: updateLog } = useUpdateRoastLog();
 
-  if (logLoading || beansLoading || levelsLoading || devicesLoading)
+  if (
+    logLoading ||
+    beansLoading ||
+    levelsLoading ||
+    devicesLoading ||
+    flavorTagsLoading
+  )
     return null;
   if (!log) return <p>ログが見つかりません</p>;
 
@@ -51,6 +60,7 @@ export function RoastLogEditPage({ logId }: RoastLogEditPageProps) {
         beans={beans}
         roastLevels={levels}
         roastDevices={devices}
+        flavorTags={flavorTags}
         submitLabel="保存"
         onSubmit={async (input: CreateRoastLogInput) => {
           await updateLog({ ...log, ...input });

--- a/src/components/RoastLogForm.test.tsx
+++ b/src/components/RoastLogForm.test.tsx
@@ -69,6 +69,7 @@ function renderForm(
       beans={[BEAN]}
       roastLevels={[LEVEL]}
       roastDevices={[DEVICE]}
+      flavorTags={[]}
       submitLabel="登録"
       onSubmit={onSubmit}
     />,

--- a/src/components/RoastLogForm.tsx
+++ b/src/components/RoastLogForm.tsx
@@ -1,5 +1,6 @@
 import { useForm, useStore } from "@tanstack/react-form";
 import { z } from "zod";
+import { StarRating } from "@/components/StarRating";
 import { TimePicker } from "@/components/TimePicker";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -15,8 +16,10 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { calcWeightLossRate } from "@/domain/roastLog";
 import type { Bean } from "@/schemas/bean";
-import type { RoastDevice, RoastLevel } from "@/schemas/masterData";
+import type { FlavorTag, RoastDevice, RoastLevel } from "@/schemas/masterData";
 import type { CreateRoastLogInput } from "@/schemas/roastLog";
+
+const TastingAxisScore = z.number().int().min(1).max(5).nullable();
 
 const FormSchema = z.object({
   beanId: z.string().min(1, "豆を選択してください"),
@@ -34,6 +37,14 @@ const FormSchema = z.object({
     .positive("焙煎後重量は0より大きい値を入力してください"),
   indoorTempC: z.number().nullable(),
   processNote: z.string(),
+  flavorTagIds: z.array(z.string()),
+  sweetness: TastingAxisScore,
+  acidity: TastingAxisScore,
+  body: TastingAxisScore,
+  bitterness: TastingAxisScore,
+  aftertaste: TastingAxisScore,
+  cleanliness: TastingAxisScore,
+  overallScore: TastingAxisScore,
 });
 
 interface RoastLogFormProps {
@@ -41,6 +52,7 @@ interface RoastLogFormProps {
   beans: Bean[];
   roastLevels: RoastLevel[];
   roastDevices: RoastDevice[];
+  flavorTags: FlavorTag[];
   submitLabel: string;
   onSubmit: (input: CreateRoastLogInput) => void | Promise<void>;
 }
@@ -50,6 +62,7 @@ export function RoastLogForm({
   beans,
   roastLevels,
   roastDevices,
+  flavorTags,
   submitLabel,
   onSubmit,
 }: RoastLogFormProps) {
@@ -66,12 +79,45 @@ export function RoastLogForm({
       weightAfterG: defaultValues.weightAfterG,
       indoorTempC: defaultValues.indoorTempC,
       processNote: defaultValues.processNote,
+      flavorTagIds: defaultValues.tasting?.flavorTags ?? [],
+      sweetness: defaultValues.tasting?.sweetness ?? null,
+      acidity: defaultValues.tasting?.acidity ?? null,
+      body: defaultValues.tasting?.body ?? null,
+      bitterness: defaultValues.tasting?.bitterness ?? null,
+      aftertaste: defaultValues.tasting?.aftertaste ?? null,
+      cleanliness: defaultValues.tasting?.cleanliness ?? null,
+      overallScore: defaultValues.overallScore ?? null,
     },
     validators: { onSubmit: FormSchema },
     onSubmit: async ({ value }) => {
+      const {
+        flavorTagIds,
+        sweetness,
+        acidity,
+        body,
+        bitterness,
+        aftertaste,
+        cleanliness,
+        overallScore,
+        ...formRest
+      } = value;
+      const tasting =
+        sweetness && acidity && body && bitterness && aftertaste && cleanliness
+          ? {
+              flavorTags: flavorTagIds,
+              sweetness,
+              acidity,
+              body,
+              bitterness,
+              aftertaste,
+              cleanliness,
+            }
+          : null;
       await onSubmit({
         ...defaultValues,
-        ...value,
+        ...formRest,
+        tasting,
+        overallScore,
       });
     },
   });
@@ -350,6 +396,149 @@ export function RoastLogForm({
           </div>
         )}
       </form.Field>
+
+      {/* テイスティング */}
+      <div className="border-t pt-4 flex flex-col gap-4">
+        <p className="text-sm font-medium text-muted-foreground">
+          テイスティング（任意）
+        </p>
+
+        {/* フレーバーノート */}
+        {flavorTags.length > 0 && (
+          <form.Field name="flavorTagIds">
+            {(field) => (
+              <fieldset className="border-0 p-0 m-0">
+                <legend className="text-sm text-muted-foreground mb-2">
+                  フレーバーノート
+                </legend>
+                <div className="flex flex-wrap gap-2">
+                  {flavorTags.map((tag) => {
+                    const selected = field.state.value.includes(tag.id);
+                    return (
+                      <button
+                        key={tag.id}
+                        type="button"
+                        aria-pressed={selected}
+                        onClick={() => {
+                          const next = selected
+                            ? field.state.value.filter((id) => id !== tag.id)
+                            : [...field.state.value, tag.id];
+                          field.handleChange(next);
+                        }}
+                        style={{
+                          background: selected ? `${tag.color}1A` : undefined,
+                          color: selected ? tag.color : undefined,
+                          borderColor: selected ? `${tag.color}66` : undefined,
+                        }}
+                        className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium cursor-pointer border ${
+                          selected
+                            ? ""
+                            : "border-border text-muted-foreground bg-muted"
+                        }`}
+                      >
+                        <span
+                          className="w-1.5 h-1.5 rounded-full"
+                          style={{
+                            background: selected
+                              ? tag.color
+                              : "var(--muted-foreground)",
+                          }}
+                        />
+                        {tag.name}
+                      </button>
+                    );
+                  })}
+                </div>
+              </fieldset>
+            )}
+          </form.Field>
+        )}
+
+        {/* 6軸評価 */}
+        <div className="flex flex-col gap-3">
+          <form.Field name="sweetness">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm">甘さ</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+          <form.Field name="acidity">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm">酸味</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+          <form.Field name="body">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm">コク</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+          <form.Field name="bitterness">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm">苦み</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+          <form.Field name="aftertaste">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm">後味</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+          <form.Field name="cleanliness">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm">クリーン</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+        </div>
+
+        {/* 総合評価 */}
+        <div className="border-t pt-3">
+          <form.Field name="overallScore">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm font-medium">総合評価</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+        </div>
+      </div>
 
       <Button type="submit">{submitLabel}</Button>
     </form>


### PR DESCRIPTION
## Summary

- **RoastLogForm**: テイスティングセクションを追加
  - FlavorTagPicker（複数選択、アクティブ時にタグ色で背景表示）
  - 6軸 StarRating（甘さ / 酸味 / コク / 苦み / 後味 / クリーン、各 1〜5）
  - 総合評価 StarRating（6軸と独立）
  - 全6軸が入力されたときのみ `tasting` オブジェクトを構築、未入力は `tasting: null`
- **RoastLogCreatePage / RoastLogEditPage**: `useFlavorTags` フックを追加し `flavorTags` を `RoastLogForm` へ渡す
- **RoastLogDetailPage**: Tasting 表示セクション（フレーバータグ・6軸スコア・総合評価）を追加
- **Cleanliness 警告**: `cleanliness ≤ 2` の場合のログ一覧カード警告色は Slice 4 で実装済み（変更なし）

## Test plan

- [x] `npm run test:run` → 148 passed
- [x] `npx tsc --noEmit` → エラーなし
- [x] `npm run lint:fix` → エラーなし
- [x] `npm run arch:check` → 依存関係違反なし
- [x] `RoastLogDetailPage`: Tasting 表示テスト 2 件追加
- [x] `RoastLogCreatePage`: 保存後遷移テストのタイミングバグ修正

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * テイスティング記録機能を新規追加。焙煎ログ作成・編集時に、フレーバータグの選択と甘さ・酸味・コク・苦味・後味・クリーンネスの6軸評価、総合評価スコアが記録できるようになりました。詳細ページではテイスティング情報が表示されます。

* **テスト**
  * テイスティングセクションの表示と詳細ページ遷移に関するテストを追加・強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->