### PR TITLE
feat(slice-7/8): WeatherCondition 自動取得 + DiffSummary パネル

### DIFF
--- a/src/components/DiffSummary.test.tsx
+++ b/src/components/DiffSummary.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react/pure";
+import { describe, expect, it } from "vitest";
+import { DiffSummary } from "@/components/DiffSummary";
+import type { RoastLog } from "@/schemas/roastLog";
+
+const BASE: RoastLog = {
+  id: "550e8400-e29b-41d4-a716-446655440010",
+  beanId: "550e8400-e29b-41d4-a716-446655440001",
+  roastDate: "2025-04-20",
+  roastLevelId: "medium",
+  roastDeviceId: null,
+  roastDurationSec: 480,
+  firstCrackSec: 300,
+  secondCrackSec: 420,
+  weightBeforeG: 250,
+  weightAfterG: 210,
+  outdoorTempC: 18,
+  outdoorHumidity: 60,
+  indoorTempC: 22,
+  tempSource: "auto",
+  weatherCode: 0,
+  tasting: null,
+  overallScore: 4,
+  processNote: "",
+};
+
+describe("DiffSummary", () => {
+  it("差分項目をすべて表示する", () => {
+    const previous: RoastLog = {
+      ...BASE,
+      id: "550e8400-e29b-41d4-a716-446655440011",
+      roastDate: "2025-04-10",
+      firstCrackSec: 280,
+      secondCrackSec: 410,
+      weightBeforeG: 250,
+      weightAfterG: 215,
+      outdoorTempC: 15,
+      indoorTempC: 20,
+      overallScore: 3,
+    };
+
+    render(<DiffSummary current={BASE} previous={previous} />);
+
+    expect(screen.getByText("前回ログとの差分")).toBeInTheDocument();
+    expect(screen.getByText("前回焙煎日: 2025-04-10")).toBeInTheDocument();
+    expect(screen.getByText("+20秒")).toBeInTheDocument(); // 1ハゼ
+    expect(screen.getByText("+10秒")).toBeInTheDocument(); // 2ハゼ
+    expect(screen.getByText("+1")).toBeInTheDocument(); // 総合評価
+    expect(screen.getByText("+3℃")).toBeInTheDocument(); // 外気温
+    expect(screen.getByText("+2℃")).toBeInTheDocument(); // 室内気温
+    expect(screen.getByText(/pt$/)).toBeInTheDocument(); // 重量減少率
+  });
+
+  it("nullable フィールドが null の場合「—」を表示する", () => {
+    const previous: RoastLog = {
+      ...BASE,
+      id: "550e8400-e29b-41d4-a716-446655440011",
+      firstCrackSec: null,
+      secondCrackSec: null,
+      outdoorTempC: null,
+      indoorTempC: null,
+      overallScore: null,
+    };
+
+    render(<DiffSummary current={BASE} previous={previous} />);
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/src/components/DiffSummary.tsx
+++ b/src/components/DiffSummary.tsx
@@ -1,0 +1,65 @@
+import { calcDiff } from "@/domain/calcDiff";
+import type { RoastLog } from "@/schemas/roastLog";
+
+interface DiffSummaryProps {
+  current: RoastLog;
+  previous: RoastLog;
+}
+
+function formatSecDiff(sec: number | null): string {
+  if (sec === null) return "—";
+  const sign = sec > 0 ? "+" : "";
+  return `${sign}${sec}秒`;
+}
+
+function formatNumberDiff(n: number | null, suffix: string): string {
+  if (n === null) return "—";
+  const sign = n > 0 ? "+" : "";
+  return `${sign}${n}${suffix}`;
+}
+
+function formatRateDiff(n: number): string {
+  const sign = n > 0 ? "+" : "";
+  return `${sign}${n.toFixed(1)}pt`;
+}
+
+export function DiffSummary({ current, previous }: DiffSummaryProps) {
+  const diff = calcDiff(current, previous);
+
+  return (
+    <section
+      className="border-t pt-4 flex flex-col gap-2"
+      aria-labelledby="diff-summary-heading"
+    >
+      <h2 id="diff-summary-heading" className="text-sm font-medium">
+        前回ログとの差分
+      </h2>
+      <p className="text-xs text-muted-foreground">
+        前回焙煎日: {previous.roastDate}
+      </p>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+        <dt className="text-muted-foreground">1ハゼ差</dt>
+        <dd>{formatSecDiff(diff.firstCrackDiffSec)}</dd>
+
+        <dt className="text-muted-foreground">2ハゼ差</dt>
+        <dd>{formatSecDiff(diff.secondCrackDiffSec)}</dd>
+
+        <dt className="text-muted-foreground">重量減少率差</dt>
+        <dd>
+          {diff.weightLossRateDiffPct === null
+            ? "—"
+            : formatRateDiff(diff.weightLossRateDiffPct)}
+        </dd>
+
+        <dt className="text-muted-foreground">総合評価差</dt>
+        <dd>{formatNumberDiff(diff.overallScoreDiff, "")}</dd>
+
+        <dt className="text-muted-foreground">外気温差</dt>
+        <dd>{formatNumberDiff(diff.outdoorTempDiff, "℃")}</dd>
+
+        <dt className="text-muted-foreground">室内気温差</dt>
+        <dd>{formatNumberDiff(diff.indoorTempDiff, "℃")}</dd>
+      </dl>
+    </section>
+  );
+}

--- a/src/components/LocationSettings.tsx
+++ b/src/components/LocationSettings.tsx
@@ -1,0 +1,150 @@
+import { useForm } from "@tanstack/react-form";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAppSettings, useUpdateAppSettings } from "@/hooks/useAppSettings";
+import { AppSettingsSchema } from "@/schemas/appSettings";
+
+export function LocationSettings() {
+  const { data: settings, isLoading } = useAppSettings();
+  const update = useUpdateAppSettings();
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  if (isLoading || !settings) return null;
+
+  const handleFetchLocation = async () => {
+    setError(null);
+    if (!("geolocation" in navigator)) {
+      setError("この端末は位置情報に対応していません");
+      return;
+    }
+    setBusy(true);
+    try {
+      const position = await new Promise<GeolocationPosition>(
+        (resolve, reject) => {
+          navigator.geolocation.getCurrentPosition(resolve, reject, {
+            enableHighAccuracy: false,
+            timeout: 10_000,
+            maximumAge: 60_000,
+          });
+        },
+      );
+      await update.mutateAsync({
+        ...settings,
+        locationLat: position.coords.latitude,
+        locationLon: position.coords.longitude,
+      });
+    } catch {
+      setError("位置情報を取得できませんでした");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleClearLocation = async () => {
+    setError(null);
+    await update.mutateAsync({
+      ...settings,
+      locationLat: null,
+      locationLon: null,
+    });
+  };
+
+  const hasLocation =
+    settings.locationLat !== null && settings.locationLon !== null;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">位置情報</h2>
+        <Button onClick={handleFetchLocation} disabled={busy}>
+          {busy ? "取得中..." : "位置情報を取得する"}
+        </Button>
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        焙煎ログ作成時に外気温・湿度・天気を自動取得します。位置情報は端末内（localStorage）にのみ保存されます。
+      </p>
+
+      <div className="rounded-lg border p-3 flex flex-col gap-2">
+        {hasLocation ? (
+          <>
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-sm">
+                {settings.locationLabel || "（場所名なし）"}
+              </span>
+              <Button variant="outline" onClick={handleClearLocation}>
+                位置情報を削除
+              </Button>
+            </div>
+            <div className="text-xs font-mono text-muted-foreground">
+              緯度 {settings.locationLat?.toFixed(4)}, 経度{" "}
+              {settings.locationLon?.toFixed(4)}
+            </div>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            位置情報が設定されていません
+          </p>
+        )}
+
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+      </div>
+
+      <LocationLabelForm
+        key={settings.locationLabel}
+        currentLabel={settings.locationLabel}
+        onSubmit={async (label) => {
+          await update.mutateAsync({ ...settings, locationLabel: label });
+        }}
+      />
+    </section>
+  );
+}
+
+function LocationLabelForm({
+  currentLabel,
+  onSubmit,
+}: {
+  currentLabel: string;
+  onSubmit: (label: string) => void | Promise<void>;
+}) {
+  const form = useForm({
+    defaultValues: { locationLabel: currentLabel },
+    validators: { onSubmit: AppSettingsSchema.pick({ locationLabel: true }) },
+    onSubmit: async ({ value }) => {
+      await onSubmit(value.locationLabel);
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="flex items-end gap-2"
+    >
+      <form.Field name="locationLabel">
+        {(field) => (
+          <div className="flex flex-1 flex-col gap-1">
+            <Label htmlFor="location-label">場所の名前</Label>
+            <Input
+              id="location-label"
+              placeholder="自宅（福井）"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+          </div>
+        )}
+      </form.Field>
+      <Button type="submit">保存</Button>
+    </form>
+  );
+}

--- a/src/components/LocationSettings.tsx
+++ b/src/components/LocationSettings.tsx
@@ -36,8 +36,16 @@ export function LocationSettings() {
         locationLat: position.coords.latitude,
         locationLon: position.coords.longitude,
       });
-    } catch {
-      setError("位置情報を取得できませんでした");
+    } catch (err) {
+      console.warn("Failed to fetch location:", err);
+      if (
+        err instanceof GeolocationPositionError &&
+        err.code === err.PERMISSION_DENIED
+      ) {
+        setError("位置情報の利用が許可されていません");
+      } else {
+        setError("位置情報を取得できませんでした");
+      }
     } finally {
       setBusy(false);
     }

--- a/src/components/RoastLogCreatePage.test.tsx
+++ b/src/components/RoastLogCreatePage.test.tsx
@@ -107,9 +107,9 @@ describe("RoastLogCreatePage", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "登録" }));
 
-    await waitFor(() =>
-      expect(router.state.location.pathname).toMatch(/^\/logs\/.+$/),
-    );
-    expect(screen.getByText("詳細ページ")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(router.state.location.pathname).toMatch(/^\/logs\/.+$/);
+      expect(screen.getByText("詳細ページ")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/RoastLogCreatePage.tsx
+++ b/src/components/RoastLogCreatePage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "@tanstack/react-router";
 import { RoastLogForm } from "@/components/RoastLogForm";
 import { useBeans } from "@/hooks/useBeans";
+import { useFlavorTags } from "@/hooks/useFlavorTags";
 import { useCreateRoastLog } from "@/hooks/useMutateRoastLog";
 import { useRoastDevices } from "@/hooks/useRoastDevices";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
@@ -32,8 +33,11 @@ export function RoastLogCreatePage() {
   const { data: beans = [], isLoading: beansLoading } = useBeans();
   const { data: levels = [], isLoading: levelsLoading } = useRoastLevels();
   const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
+  const { data: flavorTags = [], isLoading: flavorTagsLoading } =
+    useFlavorTags();
 
-  if (beansLoading || levelsLoading || devicesLoading) return null;
+  if (beansLoading || levelsLoading || devicesLoading || flavorTagsLoading)
+    return null;
 
   const today = new Date();
   const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
@@ -53,6 +57,7 @@ export function RoastLogCreatePage() {
         beans={beans}
         roastLevels={levels}
         roastDevices={devices}
+        flavorTags={flavorTags}
         submitLabel="登録"
         onSubmit={async (input: CreateRoastLogInput) => {
           const log = await mutateAsync(input);

--- a/src/components/RoastLogCreatePage.tsx
+++ b/src/components/RoastLogCreatePage.tsx
@@ -1,10 +1,12 @@
 import { useNavigate } from "@tanstack/react-router";
 import { RoastLogForm } from "@/components/RoastLogForm";
+import { useAppSettings } from "@/hooks/useAppSettings";
 import { useBeans } from "@/hooks/useBeans";
 import { useFlavorTags } from "@/hooks/useFlavorTags";
 import { useCreateRoastLog } from "@/hooks/useMutateRoastLog";
 import { useRoastDevices } from "@/hooks/useRoastDevices";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
+import { useWeather } from "@/hooks/useWeather";
 import type { CreateRoastLogInput } from "@/schemas/roastLog";
 
 const EMPTY_DEFAULTS: CreateRoastLogInput = {
@@ -35,8 +37,20 @@ export function RoastLogCreatePage() {
   const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
   const { data: flavorTags = [], isLoading: flavorTagsLoading } =
     useFlavorTags();
+  const { data: appSettings, isLoading: settingsLoading } = useAppSettings();
+  const weather = useWeather(
+    appSettings?.locationLat ?? null,
+    appSettings?.locationLon ?? null,
+  );
 
-  if (beansLoading || levelsLoading || devicesLoading || flavorTagsLoading)
+  if (
+    beansLoading ||
+    levelsLoading ||
+    devicesLoading ||
+    flavorTagsLoading ||
+    settingsLoading ||
+    weather.isLoading
+  )
     return null;
 
   const today = new Date();
@@ -47,6 +61,10 @@ export function RoastLogCreatePage() {
     beanId: beans[0]?.id ?? "",
     roastLevelId: levels[0]?.id ?? "",
     roastDeviceId: devices[0]?.id ?? null,
+    outdoorTempC: weather.data?.outdoorTempC ?? null,
+    outdoorHumidity: weather.data?.outdoorHumidity ?? null,
+    weatherCode: weather.data?.weatherCode ?? null,
+    tempSource: weather.data ? "auto" : "manual",
   };
 
   return (

--- a/src/components/RoastLogDetailPage.test.tsx
+++ b/src/components/RoastLogDetailPage.test.tsx
@@ -13,7 +13,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { RoastLogDetailPage } from "@/components/RoastLogDetailPage";
 import { db } from "@/db";
 import type { Bean } from "@/schemas/bean";
-import type { RoastDevice, RoastLevel } from "@/schemas/masterData";
+import type { FlavorTag, RoastDevice, RoastLevel } from "@/schemas/masterData";
 import type { RoastLog } from "@/schemas/roastLog";
 
 const BEAN: Bean = {
@@ -47,6 +47,12 @@ const DEVICE: RoastDevice = {
   name: "手網",
   method: "",
   note: "",
+};
+
+const FLAVOR_TAG: FlavorTag = {
+  id: "tag-floral",
+  name: "フローラル",
+  color: "#F472B6",
 };
 
 const LOG: RoastLog = {
@@ -161,6 +167,55 @@ describe("RoastLogDetailPage", () => {
       expect(router.state.location.pathname).toMatch(/\/edit$/),
     );
     expect(screen.getByText("編集ページ")).toBeInTheDocument();
+  });
+
+  it("tasting がある場合に 6 軸スコアとフレーバータグを表示する", async () => {
+    const logWithTasting: RoastLog = {
+      ...LOG,
+      tasting: {
+        flavorTags: [FLAVOR_TAG.id],
+        sweetness: 4,
+        acidity: 3,
+        body: 3,
+        bitterness: 2,
+        aftertaste: 4,
+        cleanliness: 5,
+      },
+      overallScore: 4,
+    };
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastDevices.put(DEVICE);
+    await db.flavorTags.put(FLAVOR_TAG);
+    await db.roastLogs.put(logWithTasting);
+
+    renderDetailPage(LOG.id);
+
+    await waitFor(() =>
+      expect(screen.getByText("テイスティング")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("フローラル")).toBeInTheDocument();
+    expect(screen.getByText("甘さ")).toBeInTheDocument();
+    expect(screen.getByText("酸味")).toBeInTheDocument();
+    expect(screen.getByText("コク")).toBeInTheDocument();
+    expect(screen.getByText("苦み")).toBeInTheDocument();
+    expect(screen.getByText("後味")).toBeInTheDocument();
+    expect(screen.getByText("クリーン")).toBeInTheDocument();
+    expect(screen.getByText("総合評価")).toBeInTheDocument();
+  });
+
+  it("tasting が null のとき「テイスティング」セクションを表示しない", async () => {
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastDevices.put(DEVICE);
+    await db.roastLogs.put(LOG);
+
+    renderDetailPage(LOG.id);
+
+    await waitFor(() =>
+      expect(screen.getByText("エチオピア イルガチェフェ")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("テイスティング")).not.toBeInTheDocument();
   });
 
   it("「削除」ボタンでログを削除し一覧へ遷移する", async () => {

--- a/src/components/RoastLogDetailPage.tsx
+++ b/src/components/RoastLogDetailPage.tsx
@@ -7,6 +7,7 @@ import { useDeleteRoastLog } from "@/hooks/useMutateRoastLog";
 import { useRoastDevices } from "@/hooks/useRoastDevices";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
 import { useRoastLog } from "@/hooks/useRoastLogs";
+import { weatherEmoji } from "@/lib/weatherEmoji";
 
 function formatSec(sec: number | null): string {
   if (sec === null) return "—";
@@ -107,6 +108,19 @@ export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
 
         <dt className="text-muted-foreground">室内温度</dt>
         <dd>{log.indoorTempC != null ? `${log.indoorTempC}℃` : "—"}</dd>
+
+        <dt className="text-muted-foreground">天気</dt>
+        <dd>
+          <span role="img" aria-label="天気">
+            {weatherEmoji(log.weatherCode) || "—"}
+          </span>
+        </dd>
+
+        <dt className="text-muted-foreground">外気温</dt>
+        <dd>{log.outdoorTempC != null ? `${log.outdoorTempC}℃` : "—"}</dd>
+
+        <dt className="text-muted-foreground">外気湿度</dt>
+        <dd>{log.outdoorHumidity != null ? `${log.outdoorHumidity}%` : "—"}</dd>
       </dl>
 
       {log.processNote && (

--- a/src/components/RoastLogDetailPage.tsx
+++ b/src/components/RoastLogDetailPage.tsx
@@ -1,6 +1,8 @@
 import { useNavigate } from "@tanstack/react-router";
+import { StarRating } from "@/components/StarRating";
 import { calcWeightLossRate } from "@/domain/roastLog";
 import { useBeans } from "@/hooks/useBeans";
+import { useFlavorTags } from "@/hooks/useFlavorTags";
 import { useDeleteRoastLog } from "@/hooks/useMutateRoastLog";
 import { useRoastDevices } from "@/hooks/useRoastDevices";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
@@ -23,9 +25,17 @@ export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
   const { data: beans = [], isLoading: beansLoading } = useBeans();
   const { data: levels = [], isLoading: levelsLoading } = useRoastLevels();
   const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
+  const { data: flavorTags = [], isLoading: flavorTagsLoading } =
+    useFlavorTags();
   const { mutateAsync: deleteLog } = useDeleteRoastLog();
 
-  if (logLoading || beansLoading || levelsLoading || devicesLoading)
+  if (
+    logLoading ||
+    beansLoading ||
+    levelsLoading ||
+    devicesLoading ||
+    flavorTagsLoading
+  )
     return null;
   if (!log) return <p>ログが見つかりません</p>;
 
@@ -33,6 +43,8 @@ export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
   const level = levels.find((l) => l.id === log.roastLevelId);
   const device = devices.find((d) => d.id === log.roastDeviceId);
   const rate = calcWeightLossRate(log.weightBeforeG, log.weightAfterG);
+  const flavorTagMap = Object.fromEntries(flavorTags.map((t) => [t.id, t]));
+  const tasting = log.tasting;
 
   const handleDelete = async () => {
     await deleteLog(logId);
@@ -101,6 +113,67 @@ export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
         <div>
           <p className="text-sm text-muted-foreground mb-1">焙煎メモ</p>
           <p className="text-sm">{log.processNote}</p>
+        </div>
+      )}
+
+      {/* 総合評価 */}
+      {log.overallScore != null && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">総合評価</p>
+          <StarRating value={log.overallScore} size={18} />
+        </div>
+      )}
+
+      {/* テイスティング */}
+      {tasting && (
+        <div className="border-t pt-4 flex flex-col gap-3">
+          <p className="text-sm font-medium">テイスティング</p>
+
+          {tasting.flavorTags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {tasting.flavorTags.map((tagId) => {
+                const tag = flavorTagMap[tagId];
+                if (!tag) return null;
+                return (
+                  <span
+                    key={tagId}
+                    className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium"
+                    style={{
+                      background: `${tag.color}1A`,
+                      color: tag.color,
+                      border: `0.5px solid ${tag.color}66`,
+                    }}
+                  >
+                    <span
+                      className="w-1.5 h-1.5 rounded-full"
+                      style={{ background: tag.color }}
+                    />
+                    {tag.name}
+                  </span>
+                );
+              })}
+            </div>
+          )}
+
+          <dl className="flex flex-col gap-2">
+            {(
+              [
+                { key: "sweetness", label: "甘さ" },
+                { key: "acidity", label: "酸味" },
+                { key: "body", label: "コク" },
+                { key: "bitterness", label: "苦み" },
+                { key: "aftertaste", label: "後味" },
+                { key: "cleanliness", label: "クリーン" },
+              ] as const
+            ).map(({ key, label }) => (
+              <div key={key} className="flex items-center justify-between">
+                <dt className="text-sm text-muted-foreground">{label}</dt>
+                <dd>
+                  <StarRating value={tasting[key]} size={14} />
+                </dd>
+              </div>
+            ))}
+          </dl>
         </div>
       )}
     </div>

--- a/src/components/RoastLogEditPage.tsx
+++ b/src/components/RoastLogEditPage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "@tanstack/react-router";
 import { RoastLogForm } from "@/components/RoastLogForm";
 import { useBeans } from "@/hooks/useBeans";
+import { useFlavorTags } from "@/hooks/useFlavorTags";
 import { useUpdateRoastLog } from "@/hooks/useMutateRoastLog";
 import { useRoastDevices } from "@/hooks/useRoastDevices";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
@@ -17,9 +18,17 @@ export function RoastLogEditPage({ logId }: RoastLogEditPageProps) {
   const { data: beans = [], isLoading: beansLoading } = useBeans();
   const { data: levels = [], isLoading: levelsLoading } = useRoastLevels();
   const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
+  const { data: flavorTags = [], isLoading: flavorTagsLoading } =
+    useFlavorTags();
   const { mutateAsync: updateLog } = useUpdateRoastLog();
 
-  if (logLoading || beansLoading || levelsLoading || devicesLoading)
+  if (
+    logLoading ||
+    beansLoading ||
+    levelsLoading ||
+    devicesLoading ||
+    flavorTagsLoading
+  )
     return null;
   if (!log) return <p>ログが見つかりません</p>;
 
@@ -51,6 +60,7 @@ export function RoastLogEditPage({ logId }: RoastLogEditPageProps) {
         beans={beans}
         roastLevels={levels}
         roastDevices={devices}
+        flavorTags={flavorTags}
         submitLabel="保存"
         onSubmit={async (input: CreateRoastLogInput) => {
           await updateLog({ ...log, ...input });

--- a/src/components/RoastLogForm.test.tsx
+++ b/src/components/RoastLogForm.test.tsx
@@ -69,6 +69,7 @@ function renderForm(
       beans={[BEAN]}
       roastLevels={[LEVEL]}
       roastDevices={[DEVICE]}
+      flavorTags={[]}
       submitLabel="登録"
       onSubmit={onSubmit}
     />,

--- a/src/components/RoastLogForm.tsx
+++ b/src/components/RoastLogForm.tsx
@@ -1,5 +1,6 @@
 import { useForm, useStore } from "@tanstack/react-form";
 import { z } from "zod";
+import { StarRating } from "@/components/StarRating";
 import { TimePicker } from "@/components/TimePicker";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -15,8 +16,10 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { calcWeightLossRate } from "@/domain/roastLog";
 import type { Bean } from "@/schemas/bean";
-import type { RoastDevice, RoastLevel } from "@/schemas/masterData";
+import type { FlavorTag, RoastDevice, RoastLevel } from "@/schemas/masterData";
 import type { CreateRoastLogInput } from "@/schemas/roastLog";
+
+const TastingAxisScore = z.number().int().min(1).max(5).nullable();
 
 const FormSchema = z.object({
   beanId: z.string().min(1, "豆を選択してください"),
@@ -34,6 +37,14 @@ const FormSchema = z.object({
     .positive("焙煎後重量は0より大きい値を入力してください"),
   indoorTempC: z.number().nullable(),
   processNote: z.string(),
+  flavorTagIds: z.array(z.string()),
+  sweetness: TastingAxisScore,
+  acidity: TastingAxisScore,
+  body: TastingAxisScore,
+  bitterness: TastingAxisScore,
+  aftertaste: TastingAxisScore,
+  cleanliness: TastingAxisScore,
+  overallScore: TastingAxisScore,
 });
 
 interface RoastLogFormProps {
@@ -41,6 +52,7 @@ interface RoastLogFormProps {
   beans: Bean[];
   roastLevels: RoastLevel[];
   roastDevices: RoastDevice[];
+  flavorTags: FlavorTag[];
   submitLabel: string;
   onSubmit: (input: CreateRoastLogInput) => void | Promise<void>;
 }
@@ -50,6 +62,7 @@ export function RoastLogForm({
   beans,
   roastLevels,
   roastDevices,
+  flavorTags,
   submitLabel,
   onSubmit,
 }: RoastLogFormProps) {
@@ -66,12 +79,45 @@ export function RoastLogForm({
       weightAfterG: defaultValues.weightAfterG,
       indoorTempC: defaultValues.indoorTempC,
       processNote: defaultValues.processNote,
+      flavorTagIds: defaultValues.tasting?.flavorTags ?? [],
+      sweetness: defaultValues.tasting?.sweetness ?? null,
+      acidity: defaultValues.tasting?.acidity ?? null,
+      body: defaultValues.tasting?.body ?? null,
+      bitterness: defaultValues.tasting?.bitterness ?? null,
+      aftertaste: defaultValues.tasting?.aftertaste ?? null,
+      cleanliness: defaultValues.tasting?.cleanliness ?? null,
+      overallScore: defaultValues.overallScore ?? null,
     },
     validators: { onSubmit: FormSchema },
     onSubmit: async ({ value }) => {
+      const {
+        flavorTagIds,
+        sweetness,
+        acidity,
+        body,
+        bitterness,
+        aftertaste,
+        cleanliness,
+        overallScore,
+        ...formRest
+      } = value;
+      const tasting =
+        sweetness && acidity && body && bitterness && aftertaste && cleanliness
+          ? {
+              flavorTags: flavorTagIds,
+              sweetness,
+              acidity,
+              body,
+              bitterness,
+              aftertaste,
+              cleanliness,
+            }
+          : null;
       await onSubmit({
         ...defaultValues,
-        ...value,
+        ...formRest,
+        tasting,
+        overallScore,
       });
     },
   });
@@ -350,6 +396,149 @@ export function RoastLogForm({
           </div>
         )}
       </form.Field>
+
+      {/* テイスティング */}
+      <div className="border-t pt-4 flex flex-col gap-4">
+        <p className="text-sm font-medium text-muted-foreground">
+          テイスティング（任意）
+        </p>
+
+        {/* フレーバーノート */}
+        {flavorTags.length > 0 && (
+          <form.Field name="flavorTagIds">
+            {(field) => (
+              <fieldset className="border-0 p-0 m-0">
+                <legend className="text-sm text-muted-foreground mb-2">
+                  フレーバーノート
+                </legend>
+                <div className="flex flex-wrap gap-2">
+                  {flavorTags.map((tag) => {
+                    const selected = field.state.value.includes(tag.id);
+                    return (
+                      <button
+                        key={tag.id}
+                        type="button"
+                        aria-pressed={selected}
+                        onClick={() => {
+                          const next = selected
+                            ? field.state.value.filter((id) => id !== tag.id)
+                            : [...field.state.value, tag.id];
+                          field.handleChange(next);
+                        }}
+                        style={{
+                          background: selected ? `${tag.color}1A` : undefined,
+                          color: selected ? tag.color : undefined,
+                          borderColor: selected ? `${tag.color}66` : undefined,
+                        }}
+                        className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium cursor-pointer border ${
+                          selected
+                            ? ""
+                            : "border-border text-muted-foreground bg-muted"
+                        }`}
+                      >
+                        <span
+                          className="w-1.5 h-1.5 rounded-full"
+                          style={{
+                            background: selected
+                              ? tag.color
+                              : "var(--muted-foreground)",
+                          }}
+                        />
+                        {tag.name}
+                      </button>
+                    );
+                  })}
+                </div>
+              </fieldset>
+            )}
+          </form.Field>
+        )}
+
+        {/* 6軸評価 */}
+        <div className="flex flex-col gap-3">
+          <form.Field name="sweetness">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm">甘さ</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+          <form.Field name="acidity">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm">酸味</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+          <form.Field name="body">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm">コク</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+          <form.Field name="bitterness">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm">苦み</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+          <form.Field name="aftertaste">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm">後味</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+          <form.Field name="cleanliness">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm">クリーン</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+        </div>
+
+        {/* 総合評価 */}
+        <div className="border-t pt-3">
+          <form.Field name="overallScore">
+            {(field) => (
+              <div className="flex items-center justify-between">
+                <Label className="text-sm font-medium">総合評価</Label>
+                <StarRating
+                  value={field.state.value}
+                  onChange={(v) => field.handleChange(v)}
+                />
+              </div>
+            )}
+          </form.Field>
+        </div>
+      </div>
 
       <Button type="submit">{submitLabel}</Button>
     </form>

--- a/src/components/RoastLogForm.tsx
+++ b/src/components/RoastLogForm.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { calcWeightLossRate } from "@/domain/roastLog";
+import { weatherEmoji } from "@/lib/weatherEmoji";
 import type { Bean } from "@/schemas/bean";
 import type { FlavorTag, RoastDevice, RoastLevel } from "@/schemas/masterData";
 import type { CreateRoastLogInput } from "@/schemas/roastLog";
@@ -36,6 +37,10 @@ const FormSchema = z.object({
     .number()
     .positive("焙煎後重量は0より大きい値を入力してください"),
   indoorTempC: z.number().nullable(),
+  outdoorTempC: z.number().nullable(),
+  outdoorHumidity: z.number().min(0).max(100).nullable(),
+  weatherCode: z.number().int().nullable(),
+  tempSource: z.enum(["auto", "manual"]),
   processNote: z.string(),
   flavorTagIds: z.array(z.string()),
   sweetness: TastingAxisScore,
@@ -78,6 +83,10 @@ export function RoastLogForm({
       weightBeforeG: defaultValues.weightBeforeG,
       weightAfterG: defaultValues.weightAfterG,
       indoorTempC: defaultValues.indoorTempC,
+      outdoorTempC: defaultValues.outdoorTempC,
+      outdoorHumidity: defaultValues.outdoorHumidity,
+      weatherCode: defaultValues.weatherCode,
+      tempSource: defaultValues.tempSource,
       processNote: defaultValues.processNote,
       flavorTagIds: defaultValues.tasting?.flavorTags ?? [],
       sweetness: defaultValues.tasting?.sweetness ?? null,
@@ -359,6 +368,64 @@ export function RoastLogForm({
           <span className="font-mono text-sm font-medium">
             {weightLossRate.toFixed(1)}%
           </span>
+        </div>
+      </div>
+
+      {/* 天気 */}
+      <div className="flex flex-col gap-2 rounded-md border p-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">天気</span>
+          <form.Subscribe selector={(state) => state.values.weatherCode}>
+            {(code) => {
+              const emoji = weatherEmoji(code);
+              return (
+                <span role="img" aria-label="天気" className="text-xl">
+                  {emoji || "—"}
+                </span>
+              );
+            }}
+          </form.Subscribe>
+        </div>
+        <div className="flex gap-3">
+          <form.Field name="outdoorTempC">
+            {(field) => (
+              <div className="flex flex-1 flex-col gap-1">
+                <Label htmlFor="log-outdoor-temp">外気温 (℃)</Label>
+                <Input
+                  id="log-outdoor-temp"
+                  type="number"
+                  step={0.1}
+                  value={field.state.value ?? ""}
+                  onChange={(e) => {
+                    const next =
+                      e.target.value === "" ? null : Number(e.target.value);
+                    field.handleChange(next);
+                    form.setFieldValue("tempSource", "manual");
+                  }}
+                />
+              </div>
+            )}
+          </form.Field>
+          <form.Field name="outdoorHumidity">
+            {(field) => (
+              <div className="flex flex-1 flex-col gap-1">
+                <Label htmlFor="log-outdoor-humidity">外気湿度 (%)</Label>
+                <Input
+                  id="log-outdoor-humidity"
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={1}
+                  value={field.state.value ?? ""}
+                  onChange={(e) =>
+                    field.handleChange(
+                      e.target.value === "" ? null : Number(e.target.value),
+                    )
+                  }
+                />
+              </div>
+            )}
+          </form.Field>
         </div>
       </div>
 

--- a/src/components/RoastLogListPage.tsx
+++ b/src/components/RoastLogListPage.tsx
@@ -6,6 +6,7 @@ import { calcWeightLossRate } from "@/domain/roastLog";
 import { useBeans } from "@/hooks/useBeans";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
 import { useRoastLogs } from "@/hooks/useRoastLogs";
+import { weatherEmoji } from "@/lib/weatherEmoji";
 
 const FILTERS = [
   { id: "all", label: "すべて" },
@@ -261,9 +262,19 @@ export function RoastLogListPage() {
                     fontFamily: "ui-monospace, monospace",
                     fontSize: 11,
                     color: "var(--muted-foreground)",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
                   }}
                 >
-                  {log.roastDate} · 減少率 {rate.toFixed(1)}%
+                  <span>
+                    {log.roastDate} · 減少率 {rate.toFixed(1)}%
+                  </span>
+                  {log.weatherCode != null && weatherEmoji(log.weatherCode) && (
+                    <span role="img" aria-label="天気" style={{ fontSize: 14 }}>
+                      {weatherEmoji(log.weatherCode)}
+                    </span>
+                  )}
                 </div>
 
                 <div

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { FlavorTagSettings } from "@/components/FlavorTagSettings";
+import { LocationSettings } from "@/components/LocationSettings";
 import { RoastDeviceSettings } from "@/components/RoastDeviceSettings";
 import { RoastLevelSettings } from "@/components/RoastLevelSettings";
 
@@ -15,6 +16,7 @@ export function SettingsPage() {
       <RoastLevelSettings />
       <FlavorTagSettings />
       <RoastDeviceSettings />
+      <LocationSettings />
     </div>
   );
 }

--- a/src/domain/calcDiff.test.ts
+++ b/src/domain/calcDiff.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { calcDiff } from "@/domain/calcDiff";
+import type { RoastLog } from "@/schemas/roastLog";
+
+const BASE: RoastLog = {
+  id: "550e8400-e29b-41d4-a716-446655440010",
+  beanId: "550e8400-e29b-41d4-a716-446655440001",
+  roastDate: "2025-04-20",
+  roastLevelId: "medium",
+  roastDeviceId: null,
+  roastDurationSec: 480,
+  firstCrackSec: 300,
+  secondCrackSec: 420,
+  weightBeforeG: 250,
+  weightAfterG: 210,
+  outdoorTempC: 18,
+  outdoorHumidity: 60,
+  indoorTempC: 22,
+  tempSource: "auto",
+  weatherCode: 0,
+  tasting: null,
+  overallScore: 4,
+  processNote: "",
+};
+
+describe("calcDiff", () => {
+  it("両方のフィールドが揃っている場合 current - previous を返す", () => {
+    const previous: RoastLog = {
+      ...BASE,
+      id: "550e8400-e29b-41d4-a716-446655440011",
+      firstCrackSec: 280,
+      secondCrackSec: 400,
+      weightBeforeG: 250,
+      weightAfterG: 215,
+      outdoorTempC: 15,
+      indoorTempC: 20,
+      overallScore: 3,
+    };
+    const current: RoastLog = {
+      ...BASE,
+      firstCrackSec: 300,
+      secondCrackSec: 420,
+      weightBeforeG: 250,
+      weightAfterG: 210,
+      outdoorTempC: 18,
+      indoorTempC: 22,
+      overallScore: 4,
+    };
+
+    const diff = calcDiff(current, previous);
+
+    expect(diff.firstCrackDiffSec).toBe(20);
+    expect(diff.secondCrackDiffSec).toBe(20);
+    // current 16% - previous 14% = 2pt
+    expect(diff.weightLossRateDiffPct).toBeCloseTo(2);
+    expect(diff.overallScoreDiff).toBe(1);
+    expect(diff.outdoorTempDiff).toBe(3);
+    expect(diff.indoorTempDiff).toBe(2);
+  });
+
+  it("current 側の nullable フィールドが null の場合は差分も null", () => {
+    const previous: RoastLog = { ...BASE };
+    const current: RoastLog = {
+      ...BASE,
+      firstCrackSec: null,
+      secondCrackSec: null,
+      outdoorTempC: null,
+      indoorTempC: null,
+      overallScore: null,
+    };
+
+    const diff = calcDiff(current, previous);
+
+    expect(diff.firstCrackDiffSec).toBeNull();
+    expect(diff.secondCrackDiffSec).toBeNull();
+    expect(diff.outdoorTempDiff).toBeNull();
+    expect(diff.indoorTempDiff).toBeNull();
+    expect(diff.overallScoreDiff).toBeNull();
+  });
+
+  it("previous 側の nullable フィールドが null の場合も差分は null", () => {
+    const previous: RoastLog = {
+      ...BASE,
+      firstCrackSec: null,
+      secondCrackSec: null,
+      outdoorTempC: null,
+      indoorTempC: null,
+      overallScore: null,
+    };
+    const current: RoastLog = { ...BASE };
+
+    const diff = calcDiff(current, previous);
+
+    expect(diff.firstCrackDiffSec).toBeNull();
+    expect(diff.secondCrackDiffSec).toBeNull();
+    expect(diff.outdoorTempDiff).toBeNull();
+    expect(diff.indoorTempDiff).toBeNull();
+    expect(diff.overallScoreDiff).toBeNull();
+  });
+
+  it("WeightLossRate は両方の重量から常に算出され差分は数値になる", () => {
+    const previous: RoastLog = {
+      ...BASE,
+      weightBeforeG: 200,
+      weightAfterG: 180,
+    };
+    const current: RoastLog = {
+      ...BASE,
+      weightBeforeG: 200,
+      weightAfterG: 170,
+    };
+
+    const diff = calcDiff(current, previous);
+    // current 15% - previous 10% = 5pt
+    expect(diff.weightLossRateDiffPct).toBeCloseTo(5);
+  });
+
+  it("差分が負になる場合（current < previous）は負の値を返す", () => {
+    const previous: RoastLog = { ...BASE, firstCrackSec: 320 };
+    const current: RoastLog = { ...BASE, firstCrackSec: 300 };
+
+    const diff = calcDiff(current, previous);
+    expect(diff.firstCrackDiffSec).toBe(-20);
+  });
+});

--- a/src/domain/calcDiff.ts
+++ b/src/domain/calcDiff.ts
@@ -1,0 +1,38 @@
+import { calcWeightLossRate } from "@/domain/roastLog";
+import type { RoastLog } from "@/schemas/roastLog";
+
+export interface RoastLogDiff {
+  firstCrackDiffSec: number | null;
+  secondCrackDiffSec: number | null;
+  weightLossRateDiffPct: number | null;
+  overallScoreDiff: number | null;
+  outdoorTempDiff: number | null;
+  indoorTempDiff: number | null;
+}
+
+function diffNullable(
+  current: number | null,
+  previous: number | null,
+): number | null {
+  if (current === null || previous === null) return null;
+  return current - previous;
+}
+
+export function calcDiff(current: RoastLog, previous: RoastLog): RoastLogDiff {
+  return {
+    firstCrackDiffSec: diffNullable(
+      current.firstCrackSec,
+      previous.firstCrackSec,
+    ),
+    secondCrackDiffSec: diffNullable(
+      current.secondCrackSec,
+      previous.secondCrackSec,
+    ),
+    weightLossRateDiffPct:
+      calcWeightLossRate(current.weightBeforeG, current.weightAfterG) -
+      calcWeightLossRate(previous.weightBeforeG, previous.weightAfterG),
+    overallScoreDiff: diffNullable(current.overallScore, previous.overallScore),
+    outdoorTempDiff: diffNullable(current.outdoorTempC, previous.outdoorTempC),
+    indoorTempDiff: diffNullable(current.indoorTempC, previous.indoorTempC),
+  };
+}

--- a/src/hooks/useAppSettings.ts
+++ b/src/hooks/useAppSettings.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type AppSettings,
+  AppSettingsSchema,
+  DEFAULT_APP_SETTINGS,
+} from "@/schemas/appSettings";
+
+const STORAGE_KEY = "roastlog.appSettings";
+const QUERY_KEY = ["appSettings"] as const;
+
+function readSettings(): AppSettings {
+  if (typeof window === "undefined") return DEFAULT_APP_SETTINGS;
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (raw === null) return DEFAULT_APP_SETTINGS;
+  try {
+    const parsed = AppSettingsSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : DEFAULT_APP_SETTINGS;
+  } catch {
+    return DEFAULT_APP_SETTINGS;
+  }
+}
+
+function writeSettings(settings: AppSettings): void {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+}
+
+export function useAppSettings() {
+  return useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: () => readSettings(),
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+}
+
+export function useUpdateAppSettings() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (settings: AppSettings): Promise<AppSettings> => {
+      const validated = AppSettingsSchema.parse(settings);
+      writeSettings(validated);
+      return validated;
+    },
+    onSuccess: (settings) => {
+      qc.setQueryData(QUERY_KEY, settings);
+    },
+  });
+}

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,0 +1,46 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  type OpenMeteoResponse,
+  OpenMeteoResponseSchema,
+} from "@/schemas/openMeteo";
+
+export interface WeatherSnapshot {
+  outdoorTempC: number;
+  outdoorHumidity: number;
+  weatherCode: number;
+}
+
+async function fetchWeather(
+  lat: number,
+  lon: number,
+): Promise<WeatherSnapshot> {
+  const url = new URL("https://api.open-meteo.com/v1/forecast");
+  url.searchParams.set("latitude", String(lat));
+  url.searchParams.set("longitude", String(lon));
+  url.searchParams.set(
+    "current",
+    "temperature_2m,relative_humidity_2m,weather_code",
+  );
+
+  const res = await fetch(url.toString());
+  if (!res.ok) throw new Error(`Open-Meteo HTTP ${res.status}`);
+
+  const json: OpenMeteoResponse = OpenMeteoResponseSchema.parse(
+    await res.json(),
+  );
+  return {
+    outdoorTempC: json.current.temperature_2m,
+    outdoorHumidity: json.current.relative_humidity_2m,
+    weatherCode: json.current.weather_code,
+  };
+}
+
+export function useWeather(lat: number | null, lon: number | null) {
+  return useQuery({
+    queryKey: ["weather", lat, lon],
+    queryFn: () => fetchWeather(lat as number, lon as number),
+    enabled: lat !== null && lon !== null,
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/lib/weatherEmoji.test.ts
+++ b/src/lib/weatherEmoji.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { weatherEmoji } from "@/lib/weatherEmoji";
+
+describe("weatherEmoji", () => {
+  it("0 (快晴) を ☀️ に変換する", () => {
+    expect(weatherEmoji(0)).toBe("☀️");
+  });
+
+  it("3 (曇り) を ☁️ に変換する", () => {
+    expect(weatherEmoji(3)).toBe("☁️");
+  });
+
+  it("45 (霧) を 🌫️ に変換する", () => {
+    expect(weatherEmoji(45)).toBe("🌫️");
+  });
+
+  it("63 (雨: 中程度) を 🌧️ に変換する", () => {
+    expect(weatherEmoji(63)).toBe("🌧️");
+  });
+
+  it("73 (雪: 中程度) を 🌨️ に変換する", () => {
+    expect(weatherEmoji(73)).toBe("🌨️");
+  });
+
+  it("95 (雷雨) を ⛈️ に変換する", () => {
+    expect(weatherEmoji(95)).toBe("⛈️");
+  });
+
+  it("未定義の WMO コードは空文字を返す", () => {
+    expect(weatherEmoji(999)).toBe("");
+  });
+
+  it("null の場合は空文字を返す", () => {
+    expect(weatherEmoji(null)).toBe("");
+  });
+
+  it("undefined の場合は空文字を返す", () => {
+    expect(weatherEmoji(undefined)).toBe("");
+  });
+});

--- a/src/lib/weatherEmoji.ts
+++ b/src/lib/weatherEmoji.ts
@@ -1,0 +1,37 @@
+// WMO Weather interpretation codes (https://open-meteo.com/en/docs)
+// Maps each documented WMO code to a single representative emoji.
+const WEATHER_EMOJI_MAP: Record<number, string> = {
+  0: "☀️", // Clear sky
+  1: "🌤️", // Mainly clear
+  2: "⛅", // Partly cloudy
+  3: "☁️", // Overcast
+  45: "🌫️", // Fog
+  48: "🌫️", // Depositing rime fog
+  51: "🌦️", // Drizzle: light
+  53: "🌦️", // Drizzle: moderate
+  55: "🌦️", // Drizzle: dense
+  56: "🌧️", // Freezing drizzle: light
+  57: "🌧️", // Freezing drizzle: dense
+  61: "🌧️", // Rain: slight
+  63: "🌧️", // Rain: moderate
+  65: "🌧️", // Rain: heavy
+  66: "🌧️", // Freezing rain: light
+  67: "🌧️", // Freezing rain: heavy
+  71: "🌨️", // Snow fall: slight
+  73: "🌨️", // Snow fall: moderate
+  75: "🌨️", // Snow fall: heavy
+  77: "🌨️", // Snow grains
+  80: "🌧️", // Rain showers: slight
+  81: "🌧️", // Rain showers: moderate
+  82: "⛈️", // Rain showers: violent
+  85: "🌨️", // Snow showers: slight
+  86: "🌨️", // Snow showers: heavy
+  95: "⛈️", // Thunderstorm: slight or moderate
+  96: "⛈️", // Thunderstorm with slight hail
+  99: "⛈️", // Thunderstorm with heavy hail
+};
+
+export function weatherEmoji(code: number | null | undefined): string {
+  if (code == null) return "";
+  return WEATHER_EMOJI_MAP[code] ?? "";
+}

--- a/src/schemas/appSettings.test.ts
+++ b/src/schemas/appSettings.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { AppSettingsSchema, DEFAULT_APP_SETTINGS } from "@/schemas/appSettings";
+
+describe("AppSettingsSchema", () => {
+  it("有効な設定を受け入れる", () => {
+    expect(
+      AppSettingsSchema.safeParse({
+        locationLat: 36.0641,
+        locationLon: 136.2196,
+        locationLabel: "自宅（福井）",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("緯度経度が null でも有効", () => {
+    expect(AppSettingsSchema.safeParse(DEFAULT_APP_SETTINGS).success).toBe(
+      true,
+    );
+  });
+
+  it("緯度が範囲外（91）のとき失敗する", () => {
+    expect(
+      AppSettingsSchema.safeParse({
+        locationLat: 91,
+        locationLon: 0,
+        locationLabel: "",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("経度が範囲外（-181）のとき失敗する", () => {
+    expect(
+      AppSettingsSchema.safeParse({
+        locationLat: 0,
+        locationLon: -181,
+        locationLabel: "",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/schemas/appSettings.ts
+++ b/src/schemas/appSettings.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const AppSettingsSchema = z.object({
+  locationLat: z.number().min(-90).max(90).nullable(),
+  locationLon: z.number().min(-180).max(180).nullable(),
+  locationLabel: z.string(),
+});
+
+export type AppSettings = z.infer<typeof AppSettingsSchema>;
+
+export const DEFAULT_APP_SETTINGS: AppSettings = {
+  locationLat: null,
+  locationLon: null,
+  locationLabel: "",
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,11 @@ export default defineConfig({
         test: {
           name: "unit",
           environment: "node",
-          include: ["src/domain/**/*.test.ts", "src/schemas/**/*.test.ts"],
+          include: [
+            "src/domain/**/*.test.ts",
+            "src/schemas/**/*.test.ts",
+            "src/lib/**/*.test.ts",
+          ],
         },
       },
       {


### PR DESCRIPTION
## Summary

- **Slice 7 (Issue #8)**: Open-Meteo + 位置情報設定 + 天気絵文字
  - `AppSettingsSchema` + `useAppSettings` / `useUpdateAppSettings` — 緯度・経度・場所名を localStorage に保存
  - `LocationSettings` コンポーネント — Geolocation API で取得・削除・場所名編集
  - `useWeather` フック — Open-Meteo API から外気温・湿度・WMO 天気コードを取得（失敗はサイレント）
  - `RoastLogCreatePage` — フォームを開いた時点で天気を自動入力し `tempSource` を記録；手動変更で `"manual"` に切り替え
  - `lib/weatherEmoji.ts` — WMO コード → 絵文字変換；一覧カード・詳細・フォームに表示
- **Slice 8 (Issue #9)**: DiffSummary パネル（同一 Bean の直前 RoastLog との差分比較）
  - `domain/calcDiff.ts` — 純粋関数。1ハゼ・2ハゼ・重量減少率・総合評価・外気温・室内気温の差分を算出
  - `DiffSummary` コンポーネント — 詳細画面に差分パネルとして追加予定のベースコンポーネント
- `vitest.config.ts` — `src/lib/**/*.test.ts` を unit プロジェクトへ追加
- lint: `aria-label` を持つ表示専用 `<span>` に `role="img"` を付与。`form.Subscribe` の `children` prop を JSX children に修正

## Test plan

- [x] `npm run test:run` — 168 件全パス
- [x] `npm run lint:fix` — エラーなし
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npm run arch:check` — 依存ルール違反なし

Closes #8, #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ロースト記録に天気情報（天気絵文字、外気温、外気湿度）を追加しました
  * テイスティング機能を追加：フレーバーノート選択と甘さ、酸味、コク、苦み、後味、クリーンの6軸評価システムおよび総合評価を実装しました
  * 位置情報設定機能を追加：現在地の保存とラベル付けが可能になりました
  * ロースト記録の比較機能を追加：前回との差分を視覚的に表示するようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->