### PR TITLE
feat: Slice 5/7/8 — Tasting 評価・天気自動取得・DiffSummary パネル

### DIFF
--- a/src/components/RoastLogDetailPage.test.tsx
+++ b/src/components/RoastLogDetailPage.test.tsx
@@ -218,6 +218,41 @@ describe("RoastLogDetailPage", () => {
     expect(screen.queryByText("テイスティング")).not.toBeInTheDocument();
   });
 
+  it("同じ Bean の直前ログが存在する場合に DiffSummary パネルを表示する", async () => {
+    const previousLog: RoastLog = {
+      ...LOG,
+      id: "550e8400-e29b-41d4-a716-446655440098",
+      roastDate: "2025-04-10",
+      firstCrackSec: 280,
+    };
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastDevices.put(DEVICE);
+    await db.roastLogs.put(previousLog);
+    await db.roastLogs.put(LOG);
+
+    renderDetailPage(LOG.id);
+
+    await waitFor(() =>
+      expect(screen.getByText("前回ログとの差分")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("前回焙煎日: 2025-04-10")).toBeInTheDocument();
+  });
+
+  it("Bean の最初のログ（直前ログなし）では DiffSummary パネルを表示しない", async () => {
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastDevices.put(DEVICE);
+    await db.roastLogs.put(LOG);
+
+    renderDetailPage(LOG.id);
+
+    await waitFor(() =>
+      expect(screen.getByText("エチオピア イルガチェフェ")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("前回ログとの差分")).not.toBeInTheDocument();
+  });
+
   it("「削除」ボタンでログを削除し一覧へ遷移する", async () => {
     await db.beans.put(BEAN);
     await db.roastLevels.put(LEVEL);

--- a/src/components/RoastLogDetailPage.tsx
+++ b/src/components/RoastLogDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
+import { DiffSummary } from "@/components/DiffSummary";
 import { StarRating } from "@/components/StarRating";
 import { calcWeightLossRate } from "@/domain/roastLog";
 import { useBeans } from "@/hooks/useBeans";
@@ -6,7 +7,7 @@ import { useFlavorTags } from "@/hooks/useFlavorTags";
 import { useDeleteRoastLog } from "@/hooks/useMutateRoastLog";
 import { useRoastDevices } from "@/hooks/useRoastDevices";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
-import { useRoastLog } from "@/hooks/useRoastLogs";
+import { usePreviousRoastLog, useRoastLog } from "@/hooks/useRoastLogs";
 import { weatherEmoji } from "@/lib/weatherEmoji";
 
 function formatSec(sec: number | null): string {
@@ -28,6 +29,8 @@ export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
   const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
   const { data: flavorTags = [], isLoading: flavorTagsLoading } =
     useFlavorTags();
+  const { data: previousLog, isLoading: previousLogLoading } =
+    usePreviousRoastLog(logId, log?.beanId ?? null);
   const { mutateAsync: deleteLog } = useDeleteRoastLog();
 
   if (
@@ -35,7 +38,8 @@ export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
     beansLoading ||
     levelsLoading ||
     devicesLoading ||
-    flavorTagsLoading
+    flavorTagsLoading ||
+    previousLogLoading
   )
     return null;
   if (!log) return <p>ログが見つかりません</p>;
@@ -137,6 +141,8 @@ export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
           <StarRating value={log.overallScore} size={18} />
         </div>
       )}
+
+      {previousLog && <DiffSummary current={log} previous={previousLog} />}
 
       {/* テイスティング */}
       {tasting && (

--- a/src/hooks/useRoastLogs.test.tsx
+++ b/src/hooks/useRoastLogs.test.tsx
@@ -7,7 +7,7 @@ import {
   useCreateRoastLog,
   useDeleteRoastLog,
 } from "@/hooks/useMutateRoastLog";
-import { useRoastLogs } from "@/hooks/useRoastLogs";
+import { usePreviousRoastLog, useRoastLogs } from "@/hooks/useRoastLogs";
 
 function makeWrapper(qc: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -171,5 +171,88 @@ describe("useRoastLogs", () => {
       del.current.mutate(logId);
     });
     await waitFor(() => expect(logs.current.data).toHaveLength(0));
+  });
+});
+
+const BEAN_ID = "550e8400-e29b-41d4-a716-446655440001";
+
+const LOG_A: Parameters<typeof db.roastLogs.put>[0] = {
+  id: "550e8400-e29b-41d4-a716-446655440010",
+  beanId: BEAN_ID,
+  roastDate: "2025-04-20",
+  roastLevelId: "medium",
+  roastDeviceId: null,
+  roastDurationSec: 480,
+  firstCrackSec: 300,
+  secondCrackSec: null,
+  weightBeforeG: 250,
+  weightAfterG: 210,
+  outdoorTempC: 18,
+  outdoorHumidity: 60,
+  indoorTempC: 22,
+  tempSource: "auto",
+  weatherCode: 0,
+  tasting: null,
+  overallScore: 4,
+  processNote: "",
+};
+
+const LOG_B: Parameters<typeof db.roastLogs.put>[0] = {
+  ...LOG_A,
+  id: "550e8400-e29b-41d4-a716-446655440011",
+  roastDate: "2025-04-10",
+};
+
+const LOG_C: Parameters<typeof db.roastLogs.put>[0] = {
+  ...LOG_A,
+  id: "550e8400-e29b-41d4-a716-446655440012",
+  roastDate: "2025-03-01",
+};
+
+describe("usePreviousRoastLog", () => {
+  beforeEach(async () => {
+    await Promise.all([
+      db.roastLevels.clear(),
+      db.flavorTags.clear(),
+      db.roastDevices.clear(),
+      db.beans.clear(),
+      db.roastLogs.clear(),
+    ]);
+  });
+
+  it("直前のログ（roastDate 降順で1件前）を返す", async () => {
+    await db.roastLogs.bulkPut([LOG_A, LOG_B, LOG_C]);
+
+    const qc = makeQc();
+    const { result } = renderHook(
+      () => usePreviousRoastLog(LOG_A.id, BEAN_ID),
+      { wrapper: makeWrapper(qc) },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data?.id).toBe(LOG_B.id);
+  });
+
+  it("最初のログ（直前ログなし）では null を返す", async () => {
+    await db.roastLogs.bulkPut([LOG_A, LOG_B, LOG_C]);
+
+    const qc = makeQc();
+    const { result } = renderHook(
+      () => usePreviousRoastLog(LOG_C.id, BEAN_ID),
+      { wrapper: makeWrapper(qc) },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("beanId が null のとき undefined を返しクエリを実行しない", async () => {
+    const qc = makeQc();
+    const { result } = renderHook(() => usePreviousRoastLog(LOG_A.id, null), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toBeUndefined();
   });
 });

--- a/src/hooks/useRoastLogs.ts
+++ b/src/hooks/useRoastLogs.ts
@@ -17,3 +17,20 @@ export function useRoastLog(id: string) {
     queryFn: async () => (await repo.findById(id)) ?? null,
   });
 }
+
+export function usePreviousRoastLog(logId: string, beanId: string | null) {
+  return useQuery({
+    queryKey: ["roastLogs", "byBean", beanId],
+    queryFn: () => repo.findByBeanId(beanId ?? ""),
+    enabled: beanId !== null,
+    select: (logs) => {
+      const sorted = [...logs].sort(
+        (a, b) =>
+          b.roastDate.localeCompare(a.roastDate) || b.id.localeCompare(a.id),
+      );
+      const idx = sorted.findIndex((l) => l.id === logId);
+      if (idx === -1 || idx === sorted.length - 1) return null;
+      return sorted[idx + 1];
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- **Slice 5**: RoastLog フォーム・詳細画面に Tasting 評価セクション（6軸スコア + フレーバータグ）を追加
- **Slice 7**: WeatherCondition 自動取得（Open-Meteo API）と LocationSettings・AppSettings スキーマ実装
- **Slice 8**: DiffSummary パネル — 同じ Bean の直前 RoastLog との差分を詳細画面に表示

## Slice 8 詳細（issue #9）

- `usePreviousRoastLog(logId, beanId)` フックを追加（`roastDate` 降順で1件前を返す）
- Bean の最初のログでは `null` を返しパネルを非表示
- `RoastLogDetailPage` に `<DiffSummary>` を統合
- `beanId=null` 時は `enabled: false` でクエリをスキップ

## Test plan

- [ ] `npm run test:run` — 173 tests passed
- [ ] `npm run build` — ビルド成功・型エラーなし
- [ ] `npm run lint:fix` — Biome 警告なし
- [ ] `npm run arch:check` — 依存ルール違反なし
- [ ] 直前ログあり：詳細画面で「前回ログとの差分」パネルが表示される
- [ ] 最初のログ：詳細画面でパネルが非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)