### PR TITLE
feat(slice-5~6): Tasting評価 + Bean Stock管理（在庫不足警告）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -646,9 +646,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -666,9 +663,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -686,9 +680,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -706,9 +697,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2111,9 +2099,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2126,9 +2111,6 @@
       "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2143,9 +2125,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2158,9 +2137,6 @@
       "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2175,9 +2151,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2190,9 +2163,6 @@
       "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2207,9 +2177,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2222,9 +2189,6 @@
       "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2239,9 +2203,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2254,9 +2215,6 @@
       "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2271,9 +2229,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2287,9 +2242,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2302,9 +2254,6 @@
       "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2540,9 +2489,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2558,9 +2504,6 @@
       "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2578,9 +2521,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2596,9 +2536,6 @@
       "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4979,12 +4916,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5043,9 +4980,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -5429,9 +5366,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.16",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
-      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5574,9 +5511,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6294,9 +6231,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6316,9 +6250,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -6340,9 +6271,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6362,9 +6290,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/src/components/RoastLogCreatePage.test.tsx
+++ b/src/components/RoastLogCreatePage.test.tsx
@@ -88,6 +88,98 @@ describe("RoastLogCreatePage", () => {
     );
   });
 
+  it("在庫不足の場合、確認ダイアログを表示する", async () => {
+    await db.beans.put({ ...BEAN, stockG: 100 });
+    await db.roastLevels.put(LEVEL);
+
+    renderCreatePage();
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("焙煎前重量 (g)")).toBeInTheDocument(),
+    );
+
+    const beforeInput = screen.getByLabelText("焙煎前重量 (g)");
+    const afterInput = screen.getByLabelText("焙煎後重量 (g)");
+    await userEvent.clear(beforeInput);
+    await userEvent.type(beforeInput, "200");
+    await userEvent.clear(afterInput);
+    await userEvent.type(afterInput, "170");
+
+    await userEvent.click(screen.getByRole("button", { name: "登録" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("dialog", { name: "在庫不足の確認" }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("在庫不足ダイアログでキャンセルすると保存しない", async () => {
+    await db.beans.put({ ...BEAN, stockG: 100 });
+    await db.roastLevels.put(LEVEL);
+
+    const { router } = renderCreatePage();
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("焙煎前重量 (g)")).toBeInTheDocument(),
+    );
+
+    const beforeInput = screen.getByLabelText("焙煎前重量 (g)");
+    const afterInput = screen.getByLabelText("焙煎後重量 (g)");
+    await userEvent.clear(beforeInput);
+    await userEvent.type(beforeInput, "200");
+    await userEvent.clear(afterInput);
+    await userEvent.type(afterInput, "170");
+
+    await userEvent.click(screen.getByRole("button", { name: "登録" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("dialog", { name: "在庫不足の確認" }),
+      ).toBeInTheDocument(),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: "在庫不足の確認" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(router.state.location.pathname).toBe("/logs/new");
+  });
+
+  it("在庫不足ダイアログで「それでも保存」すると保存して詳細ページへ遷移する", async () => {
+    await db.beans.put({ ...BEAN, stockG: 100 });
+    await db.roastLevels.put(LEVEL);
+
+    const { router } = renderCreatePage();
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("焙煎前重量 (g)")).toBeInTheDocument(),
+    );
+
+    const beforeInput = screen.getByLabelText("焙煎前重量 (g)");
+    const afterInput = screen.getByLabelText("焙煎後重量 (g)");
+    await userEvent.clear(beforeInput);
+    await userEvent.type(beforeInput, "200");
+    await userEvent.clear(afterInput);
+    await userEvent.type(afterInput, "170");
+
+    await userEvent.click(screen.getByRole("button", { name: "登録" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("dialog", { name: "在庫不足の確認" }),
+      ).toBeInTheDocument(),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "それでも保存" }));
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toMatch(/^\/logs\/.+$/);
+      expect(screen.getByText("詳細ページ")).toBeInTheDocument();
+    });
+  });
+
   it("保存後に詳細ページへ遷移する", async () => {
     await db.beans.put(BEAN);
     await db.roastLevels.put(LEVEL);

--- a/src/components/RoastLogCreatePage.tsx
+++ b/src/components/RoastLogCreatePage.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 import { RoastLogForm } from "@/components/RoastLogForm";
 import { useAppSettings } from "@/hooks/useAppSettings";
 import { useBeans } from "@/hooks/useBeans";
@@ -32,6 +33,9 @@ const EMPTY_DEFAULTS: CreateRoastLogInput = {
 export function RoastLogCreatePage() {
   const navigate = useNavigate();
   const { mutateAsync } = useCreateRoastLog();
+  const [pendingInput, setPendingInput] = useState<CreateRoastLogInput | null>(
+    null,
+  );
   const { data: beans = [], isLoading: beansLoading } = useBeans();
   const { data: levels = [], isLoading: levelsLoading } = useRoastLevels();
   const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
@@ -67,6 +71,20 @@ export function RoastLogCreatePage() {
     tempSource: weather.data ? "auto" : "manual",
   };
 
+  async function handleSubmit(input: CreateRoastLogInput) {
+    const bean = beans.find((b) => b.id === input.beanId);
+    if (bean && bean.stockG < input.weightBeforeG) {
+      setPendingInput(input);
+      return;
+    }
+    await save(input);
+  }
+
+  async function save(input: CreateRoastLogInput) {
+    const log = await mutateAsync(input);
+    await navigate({ to: "/logs/$logId", params: { logId: log.id } });
+  }
+
   return (
     <div className="p-6">
       <h1 className="mb-4 text-2xl font-bold">新しい焙煎を記録</h1>
@@ -77,11 +95,46 @@ export function RoastLogCreatePage() {
         roastDevices={devices}
         flavorTags={flavorTags}
         submitLabel="登録"
-        onSubmit={async (input: CreateRoastLogInput) => {
-          const log = await mutateAsync(input);
-          await navigate({ to: "/logs/$logId", params: { logId: log.id } });
-        }}
+        onSubmit={handleSubmit}
       />
+      {pendingInput && (
+        <div
+          role="dialog"
+          aria-labelledby="stock-warning-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        >
+          <div className="mx-4 max-w-sm rounded-lg bg-white p-6 shadow-xl">
+            <h3 id="stock-warning-title" className="mb-3 text-lg font-semibold">
+              在庫不足の確認
+            </h3>
+            <p className="mb-6 text-sm text-gray-600">
+              在庫（
+              {beans.find((b) => b.id === pendingInput.beanId)?.stockG ?? 0}
+              g）より多い{pendingInput.weightBeforeG}
+              gを使用します。このまま保存しますか？
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                className="rounded px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+                onClick={() => setPendingInput(null)}
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+                onClick={async () => {
+                  setPendingInput(null);
+                  await save(pendingInput);
+                }}
+              >
+                それでも保存
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useRoastLogs.test.tsx
+++ b/src/hooks/useRoastLogs.test.tsx
@@ -6,6 +6,7 @@ import { db } from "@/db";
 import {
   useCreateRoastLog,
   useDeleteRoastLog,
+  useUpdateRoastLog,
 } from "@/hooks/useMutateRoastLog";
 import { usePreviousRoastLog, useRoastLogs } from "@/hooks/useRoastLogs";
 
@@ -171,6 +172,99 @@ describe("useRoastLogs", () => {
       del.current.mutate(logId);
     });
     await waitFor(() => expect(logs.current.data).toHaveLength(0));
+  });
+
+  it("useDeleteRoastLog では Bean.stockG が変化しない", async () => {
+    await db.beans.put({
+      id: BASE_INPUT.beanId,
+      name: "エチオピア イルガチェフェ",
+      origin: "エチオピア",
+      productName: "",
+      shopName: "",
+      purchasedAt: null,
+      importedAt: null,
+      stockG: 500,
+      bestLogId: null,
+      note: "",
+      totalG: 0,
+      flavorTagIds: [],
+      process: "",
+      region: "",
+      altitude: "",
+      variety: "",
+    });
+
+    const qc = makeQc();
+    const wrapper = makeWrapper(qc);
+    const { result: create } = renderHook(() => useCreateRoastLog(), {
+      wrapper,
+    });
+    const { result: del } = renderHook(() => useDeleteRoastLog(), { wrapper });
+
+    await act(async () => {
+      create.current.mutate(BASE_INPUT);
+    });
+    await waitFor(() => expect(create.current.isSuccess).toBe(true));
+
+    const logId = create.current.data?.id ?? "";
+    const stockAfterCreate =
+      (await db.beans.get(BASE_INPUT.beanId))?.stockG ?? 0;
+
+    await act(async () => {
+      del.current.mutate(logId);
+    });
+    await waitFor(() => expect(del.current.isSuccess).toBe(true));
+
+    const bean = await db.beans.get(BASE_INPUT.beanId);
+    expect(bean?.stockG).toBe(stockAfterCreate);
+  });
+
+  it("useUpdateRoastLog では Bean.stockG が変化しない", async () => {
+    await db.beans.put({
+      id: BASE_INPUT.beanId,
+      name: "エチオピア イルガチェフェ",
+      origin: "エチオピア",
+      productName: "",
+      shopName: "",
+      purchasedAt: null,
+      importedAt: null,
+      stockG: 500,
+      bestLogId: null,
+      note: "",
+      totalG: 0,
+      flavorTagIds: [],
+      process: "",
+      region: "",
+      altitude: "",
+      variety: "",
+    });
+
+    const qc = makeQc();
+    const wrapper = makeWrapper(qc);
+    const { result: create } = renderHook(() => useCreateRoastLog(), {
+      wrapper,
+    });
+    const { result: update } = renderHook(() => useUpdateRoastLog(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      create.current.mutate(BASE_INPUT);
+    });
+    await waitFor(() => expect(create.current.isSuccess).toBe(true));
+
+    const log = create.current.data;
+    if (!log) throw new Error("create.current.data is undefined");
+    const stockAfterCreate =
+      (await db.beans.get(BASE_INPUT.beanId))?.stockG ?? 0;
+
+    await act(async () => {
+      update.current.mutate({ ...log, weightBeforeG: 999 });
+    });
+    await waitFor(() => expect(update.current.isSuccess).toBe(true));
+
+    const bean = await db.beans.get(BASE_INPUT.beanId);
+    expect(bean?.stockG).toBe(stockAfterCreate);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Slice 5**: Tasting 評価セクションを RoastLog フォーム・詳細画面に統合（フレーバータグ・6軸 StarRating・総合スコア）
- **Slice 6**: Bean Stock 管理 — 新規作成時の在庫自動デクリメント + 在庫不足確認ダイアログ + テスト整備
- **Slice 7**: WeatherCondition 自動取得（Open-Meteo API）
- **Slice 8**: DiffSummary パネル（直前 RoastLog との差分比較）

## Slice 6 Acceptance Criteria

- [x] RoastLog 新規作成で保存すると `Bean.stockG` が `weightBeforeG` 分減少する
- [x] RoastLog 編集・削除では `Bean.stockG` が変化しない（フックテストで保証）
- [x] 新規作成時に stockG がマイナスになる場合、保存前に確認ダイアログを表示（キャンセル可能・強制ではない）
- [x] 豆詳細画面から stockG を手動で加減算できる
- [x] 豆一覧に現在の stockG が表示される
- [x] Stock デクリメントのリポジトリテスト（新規作成時のみ変動すること）がパスする

## Test plan

- [ ] `npm run test:run` — 全 178 件パスを確認
- [ ] 新規 RoastLog 作成フォームで在庫より多い重量を入力 → 「在庫不足の確認」ダイアログが表示される
- [ ] ダイアログで「キャンセル」→ 保存されずフォームに戻る
- [ ] ダイアログで「それでも保存」→ 保存されて詳細ページへ遷移する
- [ ] 在庫が十分な場合は警告なしで即保存・遷移する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ロースト焙煎ログ作成時に在庫不足チェック機能を追加しました
  * 要求量が利用可能な在庫を超える場合、確認ダイアログが表示されます
  * ユーザーはキャンセルするか、それでも保存するか選択できます

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otufor/RoastLog/pull/27)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->