### PR TITLE
feat(slice-9): BestRecipe 管理

### DIFF
--- a/src/components/BeanDetailPage.test.tsx
+++ b/src/components/BeanDetailPage.test.tsx
@@ -204,4 +204,144 @@ describe("BeanDetailPage", () => {
     await waitFor(() => expect(screen.getByText("パナマ")).toBeInTheDocument());
     expect(screen.getByText("まだ焙煎していません")).toBeInTheDocument();
   });
+
+  it("bestLogId が設定済みの場合、BestRecipe サマリーを表示する", async () => {
+    const beanId = crypto.randomUUID();
+    const logId = crypto.randomUUID();
+    const levelId = "medium-001";
+
+    await db.roastLevels.put({
+      id: levelId,
+      label: "中煎り",
+      color: "#B06B1E",
+      order: 3,
+    });
+    await db.roastDevices.put({
+      id: "dev-1",
+      name: "手網",
+      method: "",
+      note: "",
+    });
+
+    const log = {
+      id: logId,
+      beanId,
+      roastDate: "2025-06-01",
+      roastLevelId: levelId,
+      roastDeviceId: "dev-1",
+      roastDurationSec: 480,
+      firstCrackSec: 300,
+      secondCrackSec: null,
+      weightBeforeG: 200,
+      weightAfterG: 170,
+      outdoorTempC: null,
+      outdoorHumidity: null,
+      indoorTempC: null,
+      tempSource: "manual" as const,
+      weatherCode: null,
+      tasting: null,
+      overallScore: 5,
+      processNote: "",
+    };
+
+    await db.beans.put({
+      ...BASE_BEAN,
+      id: beanId,
+      name: "エチオピア",
+      bestLogId: logId,
+    });
+    await db.roastLogs.put(log);
+
+    renderAt(beanId);
+    await waitFor(() =>
+      expect(screen.getByText("エチオピア")).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText("BestRecipe")).toBeInTheDocument();
+    expect(screen.getAllByText("2025-06-01").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("中煎り").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/15\.0%/).length).toBeGreaterThan(0);
+  });
+
+  it("bestLogId が null の場合、BestRecipe プレースホルダーを表示する", async () => {
+    const id = crypto.randomUUID();
+    await db.beans.put({
+      ...BASE_BEAN,
+      id,
+      name: "コスタリカ",
+      bestLogId: null,
+    });
+
+    renderAt(id);
+    await waitFor(() =>
+      expect(screen.getByText("コスタリカ")).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText("BestRecipe")).toBeInTheDocument();
+    expect(screen.getByText("まだ指定されていません")).toBeInTheDocument();
+  });
+
+  it("bestLogId が null でも最高スコアのログがあれば候補として「指定」ボタンを表示する", async () => {
+    const beanId = crypto.randomUUID();
+    const logId = crypto.randomUUID();
+    const levelId = "light-001";
+
+    await db.roastLevels.put({
+      id: levelId,
+      label: "浅煎り",
+      color: "#C8A97E",
+      order: 1,
+    });
+    await db.roastDevices.put({
+      id: "dev-2",
+      name: "手網",
+      method: "",
+      note: "",
+    });
+
+    await db.beans.put({
+      ...BASE_BEAN,
+      id: beanId,
+      name: "ブラジル",
+      bestLogId: null,
+    });
+    await db.roastLogs.put({
+      id: logId,
+      beanId,
+      roastDate: "2025-07-10",
+      roastLevelId: levelId,
+      roastDeviceId: "dev-2",
+      roastDurationSec: 600,
+      firstCrackSec: 320,
+      secondCrackSec: null,
+      weightBeforeG: 300,
+      weightAfterG: 255,
+      outdoorTempC: null,
+      outdoorHumidity: null,
+      indoorTempC: null,
+      tempSource: "manual" as const,
+      weatherCode: null,
+      tasting: null,
+      overallScore: 4,
+      processNote: "",
+    });
+
+    const user = userEvent.setup();
+    renderAt(beanId);
+
+    await waitFor(() =>
+      expect(screen.getByText("ブラジル")).toBeInTheDocument(),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "BestRecipe に指定" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "BestRecipe に指定" }));
+
+    await waitFor(async () => {
+      const stored = await db.beans.get(beanId);
+      expect(stored?.bestLogId).toBe(logId);
+    });
+  });
 });

--- a/src/components/BeanDetailPage.tsx
+++ b/src/components/BeanDetailPage.tsx
@@ -5,7 +5,11 @@ import { StarRating } from "@/components/StarRating";
 import { calcWeightLossRate } from "@/domain/roastLog";
 import { useBean } from "@/hooks/useBeans";
 import { useFlavorTags } from "@/hooks/useFlavorTags";
-import { useDeleteBean, useUpdateBean } from "@/hooks/useMutateBean";
+import {
+  useDeleteBean,
+  useSetBestLog,
+  useUpdateBean,
+} from "@/hooks/useMutateBean";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
 import { useRoastLogs } from "@/hooks/useRoastLogs";
 import type { Bean } from "@/schemas/bean";
@@ -49,6 +53,7 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
   const { data: flavorTags = [], isLoading: tagsLoading } = useFlavorTags();
   const { mutateAsync: deleteBean } = useDeleteBean();
   const { mutateAsync: updateBean } = useUpdateBean();
+  const { mutateAsync: setBestLog } = useSetBestLog();
 
   const [stockSheet, setStockSheet] = useState(false);
   const [adjustAmt, setAdjustAmt] = useState("");
@@ -77,13 +82,19 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
   const beanLogs = logs
     .filter((l) => l.beanId === beanId)
     .sort((a, b) => b.roastDate.localeCompare(a.roastDate));
-  const bestLog = beanLogs
-    .filter((log) => log.overallScore != null)
-    .reduce<(typeof beanLogs)[0] | null>((best, log) => {
-      if (!best || (log.overallScore ?? 0) > (best.overallScore ?? 0))
-        return log;
-      return best;
-    }, null);
+  const bestLog = bean.bestLogId
+    ? (beanLogs.find((l) => l.id === bean.bestLogId) ?? null)
+    : null;
+  const suggestedLog =
+    bestLog === null
+      ? beanLogs
+          .filter((log) => log.overallScore != null)
+          .reduce<(typeof beanLogs)[0] | null>((best, log) => {
+            if (!best || (log.overallScore ?? 0) > (best.overallScore ?? 0))
+              return log;
+            return best;
+          }, null)
+      : null;
 
   const pct = stockPct(bean);
 
@@ -397,6 +408,166 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
             {bean.note}
           </div>
         )}
+
+        {/* BestRecipe */}
+        <div style={{ marginBottom: 12 }}>
+          <div
+            style={{
+              fontSize: 11,
+              letterSpacing: "0.06em",
+              color: "var(--muted-foreground)",
+              marginBottom: 8,
+              paddingLeft: 2,
+            }}
+          >
+            BestRecipe
+          </div>
+          {bestLog ? (
+            <div
+              style={{
+                background: "var(--card)",
+                border: "0.5px solid #2D7D52",
+                borderRadius: 10,
+                padding: "12px 14px",
+                boxShadow: "0 1px 2px rgba(28,23,20,0.04)",
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                gap: 8,
+              }}
+            >
+              <div>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    marginBottom: 4,
+                  }}
+                >
+                  {levelMap[bestLog.roastLevelId] && (
+                    <RoastBadge
+                      level={levelMap[bestLog.roastLevelId]}
+                      size="sm"
+                    />
+                  )}
+                  <span
+                    style={{
+                      fontSize: 10,
+                      fontWeight: 500,
+                      padding: "2px 7px",
+                      borderRadius: 999,
+                      background: "#E0F2E9",
+                      color: "#2D7D52",
+                    }}
+                  >
+                    ベスト
+                  </span>
+                </div>
+                <div
+                  style={{
+                    fontFamily: "ui-monospace, monospace",
+                    fontSize: 11,
+                    color: "var(--muted-foreground)",
+                  }}
+                >
+                  {bestLog.roastDate}
+                </div>
+              </div>
+              <div style={{ textAlign: "right" }}>
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "flex-end",
+                    marginBottom: 2,
+                  }}
+                >
+                  <StarRating value={bestLog.overallScore} size={12} />
+                </div>
+                <div
+                  style={{
+                    fontFamily: "ui-monospace, monospace",
+                    fontSize: 11,
+                    color: "var(--muted-foreground)",
+                  }}
+                >
+                  {calcWeightLossRate(
+                    bestLog.weightBeforeG,
+                    bestLog.weightAfterG,
+                  ).toFixed(1)}
+                  %
+                </div>
+              </div>
+            </div>
+          ) : suggestedLog ? (
+            <div
+              style={{
+                background: "var(--card)",
+                border: "0.5px solid var(--border)",
+                borderRadius: 10,
+                padding: "12px 14px",
+                boxShadow: "0 1px 2px rgba(28,23,20,0.04)",
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                gap: 8,
+              }}
+            >
+              <div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: "var(--muted-foreground)",
+                    marginBottom: 4,
+                  }}
+                >
+                  候補: {suggestedLog.roastDate}
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  {levelMap[suggestedLog.roastLevelId] && (
+                    <RoastBadge
+                      level={levelMap[suggestedLog.roastLevelId]}
+                      size="sm"
+                    />
+                  )}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() =>
+                  setBestLog({ beanId: bean.id, logId: suggestedLog.id })
+                }
+                style={{
+                  height: 34,
+                  padding: "0 12px",
+                  background: "var(--primary)",
+                  color: "var(--primary-foreground)",
+                  border: 0,
+                  borderRadius: 8,
+                  fontSize: 12,
+                  fontWeight: 500,
+                  cursor: "pointer",
+                }}
+              >
+                BestRecipe に指定
+              </button>
+            </div>
+          ) : (
+            <div
+              style={{
+                background: "var(--card)",
+                border: "0.5px solid var(--border)",
+                borderRadius: 10,
+                padding: "24px 0",
+                textAlign: "center",
+                fontSize: 13,
+                color: "var(--muted-foreground)",
+              }}
+            >
+              まだ指定されていません
+            </div>
+          )}
+        </div>
 
         {/* Roast history */}
         <div style={{ marginBottom: 16 }}>

--- a/src/components/RoastLogDetailPage.test.tsx
+++ b/src/components/RoastLogDetailPage.test.tsx
@@ -253,6 +253,29 @@ describe("RoastLogDetailPage", () => {
     expect(screen.queryByText("前回ログとの差分")).not.toBeInTheDocument();
   });
 
+  it("「BestRecipe に指定」ボタンをクリックすると bean.bestLogId が更新される", async () => {
+    await db.beans.put(BEAN);
+    await db.roastLevels.put(LEVEL);
+    await db.roastDevices.put(DEVICE);
+    await db.roastLogs.put(LOG);
+
+    const user = userEvent.setup();
+    renderDetailPage(LOG.id);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "BestRecipe に指定" }),
+      ).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("button", { name: "BestRecipe に指定" }));
+
+    await waitFor(async () => {
+      const stored = await db.beans.get(BEAN.id);
+      expect(stored?.bestLogId).toBe(LOG.id);
+    });
+  });
+
   it("「削除」ボタンでログを削除し一覧へ遷移する", async () => {
     await db.beans.put(BEAN);
     await db.roastLevels.put(LEVEL);

--- a/src/components/RoastLogDetailPage.tsx
+++ b/src/components/RoastLogDetailPage.tsx
@@ -4,6 +4,7 @@ import { StarRating } from "@/components/StarRating";
 import { calcWeightLossRate } from "@/domain/roastLog";
 import { useBeans } from "@/hooks/useBeans";
 import { useFlavorTags } from "@/hooks/useFlavorTags";
+import { useSetBestLog } from "@/hooks/useMutateBean";
 import { useDeleteRoastLog } from "@/hooks/useMutateRoastLog";
 import { useRoastDevices } from "@/hooks/useRoastDevices";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
@@ -32,6 +33,7 @@ export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
   const { data: previousLog, isLoading: previousLogLoading } =
     usePreviousRoastLog(logId, log?.beanId ?? null);
   const { mutateAsync: deleteLog } = useDeleteRoastLog();
+  const { mutateAsync: setBestLog } = useSetBestLog();
 
   if (
     logLoading ||
@@ -65,6 +67,15 @@ export function RoastLogDetailPage({ logId }: RoastLogDetailPageProps) {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">{bean?.name ?? "—"}</h1>
         <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() =>
+              log.beanId && setBestLog({ beanId: log.beanId, logId: log.id })
+            }
+            className="px-4 py-2 rounded-lg border border-border text-sm font-medium"
+          >
+            BestRecipe に指定
+          </button>
           <button
             type="button"
             onClick={handleEdit}

--- a/src/hooks/useMutateBean.ts
+++ b/src/hooks/useMutateBean.ts
@@ -54,7 +54,7 @@ export function useSetBestLog() {
       logId: string;
     }) => {
       const bean = await repo.findById(beanId);
-      if (!bean) return;
+      if (!bean) throw new Error(`Bean not found: ${beanId}`);
       await repo.save({ ...bean, bestLogId: logId });
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["beans"] }),

--- a/src/hooks/useMutateBean.ts
+++ b/src/hooks/useMutateBean.ts
@@ -42,3 +42,21 @@ export function useDeleteBean() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ["beans"] }),
   });
 }
+
+export function useSetBestLog() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      beanId,
+      logId,
+    }: {
+      beanId: string;
+      logId: string;
+    }) => {
+      const bean = await repo.findById(beanId);
+      if (!bean) return;
+      await repo.save({ ...bean, bestLogId: logId });
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["beans"] }),
+  });
+}


### PR DESCRIPTION
## Summary

- `useSetBestLog` フックを追加し `bean.bestLogId` を IndexedDB に永続化する
- `RoastLogDetailPage` に「BestRecipe に指定」ボタンを追加（クリックで `bean.bestLogId` を更新）
- `BeanDetailPage` に BestRecipe セクションを追加
  - 設定済み → 焙煎日・RoastLevel・WeightLossRate・OverallScore のサマリーを表示
  - 未設定・候補あり → 最高スコアのログを候補として提示＋「指定」ボタン
  - 未設定・候補なし → プレースホルダー「まだ指定されていません」を表示
- 焙煎履歴の「ベスト」バッジを computed 値から `bean.bestLogId` ベースに変更

Closes #10

## Test plan

- [ ] `useSetBestLog` — `bean.bestLogId` が IndexedDB に保存されることをフックテストで確認
- [ ] `RoastLogDetailPage` — ボタンクリックで `bean.bestLogId` が更新される
- [ ] `BeanDetailPage` — `bestLogId` 設定済み時にサマリーが表示される
- [ ] `BeanDetailPage` — `bestLogId` null 時にプレースホルダーが表示される
- [ ] `BeanDetailPage` — `bestLogId` null + 候補あり時に「指定」ボタンが表示され、クリックで保存される
- [ ] 全テスト 182件パス（`npm run test:run`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 焙煎ログを「ベストレシピ」として指定できるようになりました。豆の詳細ページにベストレシピカードを追加し、選択済みのサマリー／候補の推奨表示／未指定時のプレースホルダーを表示します。ログ詳細ページからも「ベストレシピに指定」できます（選択は永続化されます）。

* **テスト**
  * ベストレシピの表示・指定操作が正しく動作することを検証するテストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otufor/RoastLog/pull/29)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->