### PR TITLE
feat(slice-10): RoastLog 一覧フィルター＆ソート

### DIFF
--- a/src/components/CsvSection.tsx
+++ b/src/components/CsvSection.tsx
@@ -1,0 +1,120 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+import { db } from "@/db";
+import { downloadCSV, roastLogsToCSV } from "@/lib/csvExport";
+import { mergeImport, parseRoastLogCSV } from "@/lib/csvImport";
+import { RoastLogRepository } from "@/repositories/roastLogRepository";
+
+const repo = new RoastLogRepository(db.roastLogs);
+
+export function CsvSection() {
+  const queryClient = useQueryClient();
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [duplicateMode, setDuplicateMode] = useState<"overwrite" | "skip">(
+    "skip",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  async function handleExport() {
+    const logs = await repo.findAll();
+    const csv = roastLogsToCSV(logs);
+    const date = new Date().toISOString().slice(0, 10);
+    downloadCSV(csv, `roastlogs-${date}.csv`);
+  }
+
+  async function handleImport() {
+    setError(null);
+    setSuccess(null);
+    const file = fileRef.current?.files?.[0];
+    if (!file) {
+      setError("ファイルを選択してください");
+      return;
+    }
+    const text = await file.text();
+    const result = parseRoastLogCSV(text);
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+    const existing = await repo.findAll();
+    const merged = mergeImport(result.rows, existing, duplicateMode);
+    await Promise.all(merged.map((log) => repo.save(log)));
+    await queryClient.invalidateQueries({ queryKey: ["roastLogs"] });
+    setSuccess(`${result.rows.length} 件をインポートしました`);
+    if (fileRef.current) fileRef.current.value = "";
+  }
+
+  return (
+    <section className="flex flex-col gap-4">
+      <h2 className="text-xl font-semibold">データ管理</h2>
+
+      <div className="flex flex-col gap-2">
+        <button
+          type="button"
+          onClick={handleExport}
+          className="w-fit rounded bg-green-600 px-4 py-2 text-white hover:bg-green-700"
+        >
+          CSV エクスポート
+        </button>
+        <p className="text-sm text-gray-500">
+          全 RoastLog を CSV ファイルとしてダウンロードします
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3 rounded border p-4">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="csv-file" className="text-sm font-medium">
+            CSV ファイル
+          </label>
+          <input
+            id="csv-file"
+            ref={fileRef}
+            type="file"
+            accept=".csv"
+            className="text-sm"
+          />
+        </div>
+
+        <fieldset className="flex gap-4">
+          <legend className="mb-1 text-sm font-medium">重複 ID の処理</legend>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="duplicate-mode"
+              value="skip"
+              checked={duplicateMode === "skip"}
+              onChange={() => setDuplicateMode("skip")}
+            />
+            スキップ
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="duplicate-mode"
+              value="overwrite"
+              checked={duplicateMode === "overwrite"}
+              onChange={() => setDuplicateMode("overwrite")}
+            />
+            上書き
+          </label>
+        </fieldset>
+
+        <button
+          type="button"
+          onClick={handleImport}
+          className="w-fit rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+        >
+          インポート
+        </button>
+
+        {error && (
+          <p role="alert" className="text-sm text-red-600">
+            {error}
+          </p>
+        )}
+        {success && <p className="text-sm text-green-600">{success}</p>}
+      </div>
+    </section>
+  );
+}

--- a/src/components/RoastLogListPage.test.tsx
+++ b/src/components/RoastLogListPage.test.tsx
@@ -198,4 +198,73 @@ describe("RoastLogListPage", () => {
 
     expect(chipBean).toHaveAttribute("aria-pressed", "true");
   });
+
+  it("豆フィルターで特定の豆のログだけ表示される", async () => {
+    const BEAN_ID_2 = "550e8400-e29b-41d4-a716-446655440002";
+    const beanB: Bean = {
+      ...SAMPLE_BEAN,
+      id: BEAN_ID_2,
+      name: "コロンビア スプレモ",
+    };
+    await db.beans.put(SAMPLE_BEAN);
+    await db.beans.put(beanB);
+    await db.roastLevels.put(SAMPLE_LEVEL);
+    await db.roastLogs.put(
+      makeLog({ beanId: BEAN_ID, roastDate: "2025-04-20" }),
+    );
+    await db.roastLogs.put(
+      makeLog({ beanId: BEAN_ID_2, roastDate: "2025-04-10" }),
+    );
+
+    renderPage();
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole("button", { name: /エチオピア|コロンビア/ }),
+      ).toHaveLength(2),
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /豆/ }));
+
+    const select = await screen.findByRole("combobox", {
+      name: /豆で絞り込み/,
+    });
+    await user.selectOptions(select, "エチオピア イルガチェフェ");
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /コロンビア スプレモ/ }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("button", { name: /エチオピア イルガチェフェ/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("ソート切り替えで overallScore 降順に並ぶ", async () => {
+    await db.beans.put(SAMPLE_BEAN);
+    await db.roastLevels.put(SAMPLE_LEVEL);
+    await db.roastLogs.put(
+      makeLog({ overallScore: 2, roastDate: "2025-04-01" }),
+    );
+    await db.roastLogs.put(
+      makeLog({ overallScore: 5, roastDate: "2025-04-20" }),
+    );
+
+    renderPage();
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole("button", { name: /エチオピア/ }),
+      ).toHaveLength(2),
+    );
+
+    const user = userEvent.setup();
+    const sortSelect = screen.getByRole("combobox", { name: /並び順/ });
+    await user.selectOptions(sortSelect, "overallScore-desc");
+
+    const cards = screen.getAllByRole("button", { name: /エチオピア/ });
+    // スコア5のカード(2025-04-20)が先、スコア2のカード(2025-04-01)が後
+    expect(cards[0]).toHaveTextContent("2025-04-20");
+    expect(cards[1]).toHaveTextContent("2025-04-01");
+  });
 });

--- a/src/components/RoastLogListPage.tsx
+++ b/src/components/RoastLogListPage.tsx
@@ -2,37 +2,73 @@ import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { RoastBadge } from "@/components/RoastBadge";
 import { StarRating } from "@/components/StarRating";
-import { calcWeightLossRate } from "@/domain/roastLog";
+import {
+  calcWeightLossRate,
+  filterAndSortLogs,
+  type LogFilter,
+  type LogSortDir,
+  type LogSortKey,
+} from "@/domain/roastLog";
 import { useBeans } from "@/hooks/useBeans";
+import { useRoastDevices } from "@/hooks/useRoastDevices";
 import { useRoastLevels } from "@/hooks/useRoastLevels";
 import { useRoastLogs } from "@/hooks/useRoastLogs";
 import { weatherEmoji } from "@/lib/weatherEmoji";
 
-const FILTERS = [
+const FILTER_CHIPS = [
   { id: "all", label: "すべて" },
   { id: "bean", label: "豆" },
-  { id: "roast", label: "焙煎度" },
+  { id: "roastLevel", label: "焙煎度" },
+  { id: "device", label: "デバイス" },
   { id: "score", label: "スコア" },
   { id: "date", label: "日付" },
 ] as const;
 
+type FilterChipId = (typeof FILTER_CHIPS)[number]["id"];
+
+const SORT_OPTIONS: { value: `${LogSortKey}-${LogSortDir}`; label: string }[] =
+  [
+    { value: "roastDate-desc", label: "日付（新しい順）" },
+    { value: "roastDate-asc", label: "日付（古い順）" },
+    { value: "overallScore-desc", label: "スコア（高い順）" },
+    { value: "overallScore-asc", label: "スコア（低い順）" },
+    { value: "weightLossRate-desc", label: "減少率（高い順）" },
+    { value: "weightLossRate-asc", label: "減少率（低い順）" },
+  ];
+
 export function RoastLogListPage() {
   const navigate = useNavigate();
-  const [filter, setFilter] = useState<string>("all");
+  const [activeChip, setActiveChip] = useState<FilterChipId>("all");
+  const [filter, setFilter] = useState<LogFilter>({});
+  const [sortValue, setSortValue] =
+    useState<`${LogSortKey}-${LogSortDir}`>("roastDate-desc");
+
   const { data: logs = [], isLoading: logsLoading } = useRoastLogs();
   const { data: beans = [], isLoading: beansLoading } = useBeans();
   const { data: levels = [], isLoading: levelsLoading } = useRoastLevels();
+  const { data: devices = [], isLoading: devicesLoading } = useRoastDevices();
+
+  if (logsLoading || beansLoading || levelsLoading || devicesLoading)
+    return null;
 
   const beanMap = Object.fromEntries(beans.map((b) => [b.id, b]));
   const levelMap = Object.fromEntries(levels.map((l) => [l.id, l]));
   const bestLogIds = new Set(beans.map((b) => b.bestLogId).filter(Boolean));
 
-  // TODO: filter chips (bean/roast/score/date) are UI stubs; apply filter logic when implemented
-  const sorted = [...logs].sort((a, b) =>
-    b.roastDate.localeCompare(a.roastDate),
-  );
+  const [sortKey, sortDir] = sortValue.split("-") as [LogSortKey, LogSortDir];
+  const displayed = filterAndSortLogs(logs, filter, sortKey, sortDir);
 
-  if (logsLoading || beansLoading || levelsLoading) return null;
+  function handleChipClick(id: FilterChipId) {
+    if (activeChip === id) {
+      setActiveChip("all");
+    } else {
+      setActiveChip(id);
+    }
+  }
+
+  function handleSortChange(val: string) {
+    setSortValue(val as `${LogSortKey}-${LogSortDir}`);
+  }
 
   return (
     <div
@@ -69,36 +105,27 @@ export function RoastLogListPage() {
         >
           焙煎ログ
         </div>
-        <button
-          type="button"
-          aria-label="検索"
+        <select
+          aria-label="並び順"
+          value={sortValue}
+          onChange={(e) => handleSortChange(e.target.value)}
           style={{
-            width: 44,
-            height: 44,
-            background: "transparent",
-            border: 0,
+            height: 32,
+            padding: "0 8px",
+            border: "0.5px solid var(--border)",
+            borderRadius: 6,
+            background: "var(--card)",
             color: "var(--foreground)",
+            fontSize: 12,
             cursor: "pointer",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
           }}
         >
-          <svg
-            aria-hidden="true"
-            width="22"
-            height="22"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.75"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <circle cx="11" cy="11" r="8" />
-            <path d="M21 21l-4.3-4.3" />
-          </svg>
-        </button>
+          {SORT_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
       </header>
 
       {/* Filter chips */}
@@ -109,18 +136,19 @@ export function RoastLogListPage() {
           display: "flex",
           gap: 6,
           overflowX: "auto",
-          borderBottom: "0.5px solid var(--border)",
+          borderBottom:
+            activeChip === "all" ? "0.5px solid var(--border)" : "none",
           scrollbarWidth: "none",
         }}
       >
-        {FILTERS.map((f) => {
-          const active = filter === f.id;
+        {FILTER_CHIPS.map((f) => {
+          const active = activeChip === f.id;
           return (
             <button
               type="button"
               key={f.id}
               aria-pressed={active}
-              onClick={() => setFilter(f.id)}
+              onClick={() => handleChipClick(f.id)}
               style={{
                 flexShrink: 0,
                 height: 32,
@@ -163,6 +191,168 @@ export function RoastLogListPage() {
         })}
       </div>
 
+      {/* Filter panel */}
+      {activeChip !== "all" && (
+        <div
+          style={{
+            flexShrink: 0,
+            padding: "8px 16px 12px",
+            borderBottom: "0.5px solid var(--border)",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 8,
+            alignItems: "center",
+          }}
+        >
+          {activeChip === "bean" && (
+            <select
+              aria-label="豆で絞り込み"
+              value={filter.beanId ?? ""}
+              onChange={(e) =>
+                setFilter((f) => ({
+                  ...f,
+                  beanId: e.target.value || undefined,
+                }))
+              }
+              style={selectStyle}
+            >
+              <option value="">すべての豆</option>
+              {beans.map((b) => (
+                <option key={b.id} value={b.id}>
+                  {b.name}
+                </option>
+              ))}
+            </select>
+          )}
+
+          {activeChip === "roastLevel" && (
+            <select
+              aria-label="焙煎度で絞り込み"
+              value={filter.roastLevelId ?? ""}
+              onChange={(e) =>
+                setFilter((f) => ({
+                  ...f,
+                  roastLevelId: e.target.value || undefined,
+                }))
+              }
+              style={selectStyle}
+            >
+              <option value="">すべての焙煎度</option>
+              {levels.map((l) => (
+                <option key={l.id} value={l.id}>
+                  {l.label}
+                </option>
+              ))}
+            </select>
+          )}
+
+          {activeChip === "device" && (
+            <select
+              aria-label="デバイスで絞り込み"
+              value={filter.roastDeviceId ?? ""}
+              onChange={(e) =>
+                setFilter((f) => ({
+                  ...f,
+                  roastDeviceId: e.target.value || undefined,
+                }))
+              }
+              style={selectStyle}
+            >
+              <option value="">すべてのデバイス</option>
+              {devices.map((d) => (
+                <option key={d.id} value={d.id}>
+                  {d.name}
+                </option>
+              ))}
+            </select>
+          )}
+
+          {activeChip === "score" && (
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <label style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
+                最低
+                <input
+                  type="number"
+                  aria-label="最低スコア"
+                  min={1}
+                  max={5}
+                  value={filter.scoreMin ?? ""}
+                  onChange={(e) =>
+                    setFilter((f) => ({
+                      ...f,
+                      scoreMin: e.target.value
+                        ? Number(e.target.value)
+                        : undefined,
+                    }))
+                  }
+                  style={{ ...inputStyle, width: 56, marginLeft: 6 }}
+                />
+              </label>
+              <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
+                〜
+              </span>
+              <label style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
+                最高
+                <input
+                  type="number"
+                  aria-label="最高スコア"
+                  min={1}
+                  max={5}
+                  value={filter.scoreMax ?? ""}
+                  onChange={(e) =>
+                    setFilter((f) => ({
+                      ...f,
+                      scoreMax: e.target.value
+                        ? Number(e.target.value)
+                        : undefined,
+                    }))
+                  }
+                  style={{ ...inputStyle, width: 56, marginLeft: 6 }}
+                />
+              </label>
+            </div>
+          )}
+
+          {activeChip === "date" && (
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <label style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
+                から
+                <input
+                  type="date"
+                  aria-label="開始日"
+                  value={filter.dateFrom ?? ""}
+                  onChange={(e) =>
+                    setFilter((f) => ({
+                      ...f,
+                      dateFrom: e.target.value || undefined,
+                    }))
+                  }
+                  style={{ ...inputStyle, marginLeft: 6 }}
+                />
+              </label>
+              <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
+                〜
+              </span>
+              <label style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
+                まで
+                <input
+                  type="date"
+                  aria-label="終了日"
+                  value={filter.dateTo ?? ""}
+                  onChange={(e) =>
+                    setFilter((f) => ({
+                      ...f,
+                      dateTo: e.target.value || undefined,
+                    }))
+                  }
+                  style={{ ...inputStyle, marginLeft: 6 }}
+                />
+              </label>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Log list */}
       <div
         style={{
@@ -174,7 +364,7 @@ export function RoastLogListPage() {
           gap: 10,
         }}
       >
-        {sorted.length === 0 ? (
+        {displayed.length === 0 ? (
           <p
             style={{
               color: "var(--muted-foreground)",
@@ -186,7 +376,7 @@ export function RoastLogListPage() {
             焙煎ログがありません
           </p>
         ) : (
-          sorted.map((log) => {
+          displayed.map((log) => {
             const bean = beanMap[log.beanId];
             const level = levelMap[log.roastLevelId];
             const isBest = bestLogIds.has(log.id);
@@ -201,6 +391,7 @@ export function RoastLogListPage() {
               <button
                 type="button"
                 key={log.id}
+                aria-label={`${bean?.name ?? "—"} ${log.roastDate}`}
                 onClick={() =>
                   navigate({ to: "/logs/$logId", params: { logId: log.id } })
                 }
@@ -361,3 +552,24 @@ export function RoastLogListPage() {
     </div>
   );
 }
+
+const selectStyle: React.CSSProperties = {
+  height: 32,
+  padding: "0 8px",
+  border: "0.5px solid var(--border)",
+  borderRadius: 6,
+  background: "var(--card)",
+  color: "var(--foreground)",
+  fontSize: 12,
+  cursor: "pointer",
+};
+
+const inputStyle: React.CSSProperties = {
+  height: 32,
+  padding: "0 8px",
+  border: "0.5px solid var(--border)",
+  borderRadius: 6,
+  background: "var(--card)",
+  color: "var(--foreground)",
+  fontSize: 12,
+};

--- a/src/components/RoastLogListPage.tsx
+++ b/src/components/RoastLogListPage.tsx
@@ -59,6 +59,11 @@ export function RoastLogListPage() {
   const displayed = filterAndSortLogs(logs, filter, sortKey, sortDir);
 
   function handleChipClick(id: FilterChipId) {
+    if (id === "all") {
+      setActiveChip("all");
+      setFilter({});
+      return;
+    }
     if (activeChip === id) {
       setActiveChip("all");
     } else {

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -8,9 +8,12 @@ import {
   RouterProvider,
 } from "@tanstack/react-router";
 import { render, screen, waitFor } from "@testing-library/react/pure";
-import { beforeEach, describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SettingsPage } from "@/components/SettingsPage";
 import { db } from "@/db";
+import { roastLogsToCSV } from "@/lib/csvExport";
+import type { RoastLog } from "@/schemas/roastLog";
 
 function renderPage() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -61,5 +64,117 @@ describe("SettingsPage", () => {
     expect(
       screen.getByRole("heading", { name: "焙煎機", level: 2 }),
     ).toBeInTheDocument();
+  });
+
+  it("エクスポートボタンとインポート UI が表示される", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /CSV エクスポート/ }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText(/CSV ファイル/)).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /上書き/ })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /スキップ/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /インポート/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("エクスポートボタンクリックで downloadCSV が呼ばれる", async () => {
+    const mockCreateObjectURL = vi.fn(() => "blob:mock");
+    const mockRevokeObjectURL = vi.fn();
+    URL.createObjectURL = mockCreateObjectURL;
+    URL.revokeObjectURL = mockRevokeObjectURL;
+
+    const sampleLog: RoastLog = {
+      id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      beanId: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      roastDate: "2024-01-15",
+      roastLevelId: "medium",
+      roastDeviceId: null,
+      roastDurationSec: 720,
+      firstCrackSec: null,
+      secondCrackSec: null,
+      weightBeforeG: 200,
+      weightAfterG: 170,
+      outdoorTempC: null,
+      outdoorHumidity: null,
+      indoorTempC: null,
+      tempSource: "manual",
+      weatherCode: null,
+      tasting: null,
+      overallScore: null,
+      processNote: "",
+    };
+    await db.roastLogs.put(sampleLog);
+
+    renderPage();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /CSV エクスポート/ }),
+      ).toBeInTheDocument(),
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /CSV エクスポート/ }),
+    );
+
+    await waitFor(() => expect(mockCreateObjectURL).toHaveBeenCalledOnce());
+    expect(mockRevokeObjectURL).toHaveBeenCalledOnce();
+  });
+
+  it("不正な CSV をインポートするとエラーメッセージが表示される", async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByLabelText(/CSV ファイル/)).toBeInTheDocument(),
+    );
+
+    const file = new File(["不正,なCSV\n行1,行2"], "bad.csv", {
+      type: "text/csv",
+    });
+    await userEvent.upload(screen.getByLabelText(/CSV ファイル/), file);
+    await userEvent.click(screen.getByRole("button", { name: /インポート/ }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(screen.getByRole("alert").textContent).toMatch(/ヘッダー/);
+  });
+
+  it("正常な CSV をインポートすると RoastLog が保存される", async () => {
+    const sampleLog: RoastLog = {
+      id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      beanId: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      roastDate: "2024-01-15",
+      roastLevelId: "medium",
+      roastDeviceId: null,
+      roastDurationSec: 720,
+      firstCrackSec: null,
+      secondCrackSec: null,
+      weightBeforeG: 200,
+      weightAfterG: 170,
+      outdoorTempC: null,
+      outdoorHumidity: null,
+      indoorTempC: null,
+      tempSource: "manual",
+      weatherCode: null,
+      tasting: null,
+      overallScore: null,
+      processNote: "",
+    };
+    const csv = roastLogsToCSV([sampleLog]);
+    const file = new File([csv], "roastlogs.csv", { type: "text/csv" });
+
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByLabelText(/CSV ファイル/)).toBeInTheDocument(),
+    );
+
+    await userEvent.upload(screen.getByLabelText(/CSV ファイル/), file);
+    await userEvent.click(screen.getByRole("button", { name: /インポート/ }));
+
+    await waitFor(async () => {
+      const saved = await db.roastLogs.get(sampleLog.id);
+      expect(saved).toBeDefined();
+    });
   });
 });

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { CsvSection } from "@/components/CsvSection";
 import { FlavorTagSettings } from "@/components/FlavorTagSettings";
 import { LocationSettings } from "@/components/LocationSettings";
 import { RoastDeviceSettings } from "@/components/RoastDeviceSettings";
@@ -17,6 +18,7 @@ export function SettingsPage() {
       <FlavorTagSettings />
       <RoastDeviceSettings />
       <LocationSettings />
+      <CsvSection />
     </div>
   );
 }

--- a/src/domain/roastLog.test.ts
+++ b/src/domain/roastLog.test.ts
@@ -1,5 +1,199 @@
 import { describe, expect, it } from "vitest";
-import { calcWeightLossRate, isCleanlinessWarning } from "@/domain/roastLog";
+import {
+  calcWeightLossRate,
+  filterAndSortLogs,
+  isCleanlinessWarning,
+} from "@/domain/roastLog";
+import type { RoastLog } from "@/schemas/roastLog";
+
+const makeLog = (overrides: Partial<RoastLog> = {}): RoastLog => ({
+  id: crypto.randomUUID(),
+  beanId: "bean-1",
+  roastDate: "2025-04-20",
+  roastLevelId: "medium",
+  roastDeviceId: null,
+  roastDurationSec: 480,
+  firstCrackSec: 300,
+  secondCrackSec: null,
+  weightBeforeG: 250,
+  weightAfterG: 210,
+  outdoorTempC: null,
+  outdoorHumidity: null,
+  indoorTempC: null,
+  tempSource: "auto",
+  weatherCode: null,
+  tasting: null,
+  overallScore: 3,
+  processNote: "",
+  ...overrides,
+});
+
+describe("filterAndSortLogs", () => {
+  it("フィルターなし・デフォルトソートで roastDate 降順に並ぶ", () => {
+    const logOld = makeLog({ roastDate: "2025-04-01" });
+    const logNew = makeLog({ roastDate: "2025-04-20" });
+    const result = filterAndSortLogs([logOld, logNew], {}, "roastDate", "desc");
+    expect(result.map((l) => l.roastDate)).toEqual([
+      "2025-04-20",
+      "2025-04-01",
+    ]);
+  });
+
+  it("beanId フィルターで対象豆のみ返す", () => {
+    const logA = makeLog({ beanId: "bean-A" });
+    const logB = makeLog({ beanId: "bean-B" });
+    const result = filterAndSortLogs(
+      [logA, logB],
+      { beanId: "bean-A" },
+      "roastDate",
+      "desc",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].beanId).toBe("bean-A");
+  });
+
+  it("roastLevelId フィルターで対象レベルのみ返す", () => {
+    const logLight = makeLog({ roastLevelId: "light" });
+    const logMedium = makeLog({ roastLevelId: "medium" });
+    const result = filterAndSortLogs(
+      [logLight, logMedium],
+      { roastLevelId: "light" },
+      "roastDate",
+      "desc",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].roastLevelId).toBe("light");
+  });
+
+  it("roastDeviceId フィルターで対象デバイスのみ返す", () => {
+    const logA = makeLog({ roastDeviceId: "device-1" });
+    const logB = makeLog({ roastDeviceId: null });
+    const result = filterAndSortLogs(
+      [logA, logB],
+      { roastDeviceId: "device-1" },
+      "roastDate",
+      "desc",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].roastDeviceId).toBe("device-1");
+  });
+
+  it("scoreMin で最低スコア以上のみ返す", () => {
+    const log3 = makeLog({ overallScore: 3 });
+    const log5 = makeLog({ overallScore: 5 });
+    const logNull = makeLog({ overallScore: null });
+    const result = filterAndSortLogs(
+      [log3, log5, logNull],
+      { scoreMin: 4 },
+      "roastDate",
+      "desc",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].overallScore).toBe(5);
+  });
+
+  it("scoreMax で最高スコア以下のみ返す", () => {
+    const log2 = makeLog({ overallScore: 2 });
+    const log4 = makeLog({ overallScore: 4 });
+    const result = filterAndSortLogs(
+      [log2, log4],
+      { scoreMax: 3 },
+      "roastDate",
+      "desc",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].overallScore).toBe(2);
+  });
+
+  it("dateFrom で指定日以降のみ返す", () => {
+    const logOld = makeLog({ roastDate: "2025-03-01" });
+    const logNew = makeLog({ roastDate: "2025-04-01" });
+    const result = filterAndSortLogs(
+      [logOld, logNew],
+      { dateFrom: "2025-04-01" },
+      "roastDate",
+      "desc",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].roastDate).toBe("2025-04-01");
+  });
+
+  it("dateTo で指定日以前のみ返す", () => {
+    const logOld = makeLog({ roastDate: "2025-03-01" });
+    const logNew = makeLog({ roastDate: "2025-04-01" });
+    const result = filterAndSortLogs(
+      [logOld, logNew],
+      { dateTo: "2025-03-31" },
+      "roastDate",
+      "desc",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].roastDate).toBe("2025-03-01");
+  });
+
+  it("roastDate 昇順ソートで古い順に並ぶ", () => {
+    const logOld = makeLog({ roastDate: "2025-04-01" });
+    const logNew = makeLog({ roastDate: "2025-04-20" });
+    const result = filterAndSortLogs([logNew, logOld], {}, "roastDate", "asc");
+    expect(result.map((l) => l.roastDate)).toEqual([
+      "2025-04-01",
+      "2025-04-20",
+    ]);
+  });
+
+  it("overallScore 降順ソートで高スコア順に並ぶ", () => {
+    const log3 = makeLog({ overallScore: 3 });
+    const log5 = makeLog({ overallScore: 5 });
+    const log1 = makeLog({ overallScore: 1 });
+    const result = filterAndSortLogs(
+      [log3, log5, log1],
+      {},
+      "overallScore",
+      "desc",
+    );
+    expect(result.map((l) => l.overallScore)).toEqual([5, 3, 1]);
+  });
+
+  it("weightLossRate 降順ソートで高減少率順に並ぶ", () => {
+    // 250→200 = 20%, 250→225 = 10%
+    const logHigh = makeLog({ weightBeforeG: 250, weightAfterG: 200 });
+    const logLow = makeLog({ weightBeforeG: 250, weightAfterG: 225 });
+    const result = filterAndSortLogs(
+      [logLow, logHigh],
+      {},
+      "weightLossRate",
+      "desc",
+    );
+    expect(result[0]).toBe(logHigh);
+    expect(result[1]).toBe(logLow);
+  });
+
+  it("フィルターとソートを組み合わせる", () => {
+    const logA = makeLog({
+      beanId: "bean-A",
+      overallScore: 5,
+      roastDate: "2025-04-01",
+    });
+    const logB = makeLog({
+      beanId: "bean-A",
+      overallScore: 3,
+      roastDate: "2025-04-20",
+    });
+    const logC = makeLog({
+      beanId: "bean-B",
+      overallScore: 4,
+      roastDate: "2025-04-10",
+    });
+    const result = filterAndSortLogs(
+      [logA, logB, logC],
+      { beanId: "bean-A" },
+      "overallScore",
+      "desc",
+    );
+    expect(result).toHaveLength(2);
+    expect(result.map((l) => l.overallScore)).toEqual([5, 3]);
+  });
+});
 
 describe("calcWeightLossRate", () => {
   it("標準バッチの重量減少率を計算する", () => {

--- a/src/domain/roastLog.ts
+++ b/src/domain/roastLog.ts
@@ -1,3 +1,59 @@
+import type { RoastLog } from "@/schemas/roastLog";
+
+export type LogFilter = {
+  beanId?: string;
+  roastLevelId?: string;
+  roastDeviceId?: string;
+  scoreMin?: number;
+  scoreMax?: number;
+  dateFrom?: string;
+  dateTo?: string;
+};
+
+export type LogSortKey = "roastDate" | "overallScore" | "weightLossRate";
+export type LogSortDir = "asc" | "desc";
+
+export function filterAndSortLogs(
+  logs: RoastLog[],
+  filter: LogFilter,
+  sortKey: LogSortKey,
+  sortDir: LogSortDir,
+): RoastLog[] {
+  const filtered = logs.filter((log) => {
+    if (filter.beanId && log.beanId !== filter.beanId) return false;
+    if (filter.roastLevelId && log.roastLevelId !== filter.roastLevelId)
+      return false;
+    if (filter.roastDeviceId !== undefined) {
+      if (log.roastDeviceId !== filter.roastDeviceId) return false;
+    }
+    if (filter.scoreMin != null) {
+      if (log.overallScore == null || log.overallScore < filter.scoreMin)
+        return false;
+    }
+    if (filter.scoreMax != null) {
+      if (log.overallScore == null || log.overallScore > filter.scoreMax)
+        return false;
+    }
+    if (filter.dateFrom && log.roastDate < filter.dateFrom) return false;
+    if (filter.dateTo && log.roastDate > filter.dateTo) return false;
+    return true;
+  });
+
+  return filtered.sort((a, b) => {
+    let cmp = 0;
+    if (sortKey === "roastDate") {
+      cmp = a.roastDate.localeCompare(b.roastDate);
+    } else if (sortKey === "overallScore") {
+      cmp = (a.overallScore ?? 0) - (b.overallScore ?? 0);
+    } else {
+      cmp =
+        calcWeightLossRate(a.weightBeforeG, a.weightAfterG) -
+        calcWeightLossRate(b.weightBeforeG, b.weightAfterG);
+    }
+    return sortDir === "asc" ? cmp : -cmp;
+  });
+}
+
 export function calcWeightLossRate(
   weightBeforeG: number,
   weightAfterG: number,

--- a/src/lib/csvExport.test.ts
+++ b/src/lib/csvExport.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { roastLogsToCSV } from "@/lib/csvExport";
+import type { RoastLog } from "@/schemas/roastLog";
+
+const BASE_LOG: RoastLog = {
+  id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+  beanId: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+  roastDate: "2024-01-15",
+  roastLevelId: "medium",
+  roastDeviceId: null,
+  roastDurationSec: 720,
+  firstCrackSec: 480,
+  secondCrackSec: null,
+  weightBeforeG: 200,
+  weightAfterG: 170,
+  outdoorTempC: 15.5,
+  outdoorHumidity: 60,
+  indoorTempC: null,
+  tempSource: "auto",
+  weatherCode: 0,
+  tasting: {
+    flavorTags: ["fruity", "chocolate"],
+    sweetness: 4,
+    acidity: 3,
+    body: 3,
+    bitterness: 2,
+    aftertaste: 4,
+    cleanliness: 5,
+  },
+  overallScore: 4,
+  processNote: "順調",
+};
+
+describe("roastLogsToCSV", () => {
+  it("空配列はヘッダー行のみ返す", () => {
+    const csv = roastLogsToCSV([]);
+    const lines = csv.split("\n");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("id");
+    expect(lines[0]).toContain("beanId");
+    expect(lines[0]).toContain("roastDate");
+  });
+
+  it("ヘッダーに全フィールドが含まれる", () => {
+    const csv = roastLogsToCSV([]);
+    const headers = csv.split("\n")[0].split(",");
+    const expected = [
+      "id",
+      "beanId",
+      "roastDate",
+      "roastLevelId",
+      "roastDeviceId",
+      "roastDurationSec",
+      "firstCrackSec",
+      "secondCrackSec",
+      "weightBeforeG",
+      "weightAfterG",
+      "outdoorTempC",
+      "outdoorHumidity",
+      "indoorTempC",
+      "tempSource",
+      "weatherCode",
+      "tasting_flavorTags",
+      "tasting_sweetness",
+      "tasting_acidity",
+      "tasting_body",
+      "tasting_bitterness",
+      "tasting_aftertaste",
+      "tasting_cleanliness",
+      "overallScore",
+      "processNote",
+    ];
+    expect(headers).toEqual(expected);
+  });
+
+  it("RoastLog 1件を正しくシリアライズする", () => {
+    const csv = roastLogsToCSV([BASE_LOG]);
+    const lines = csv.split("\n");
+    expect(lines).toHaveLength(2);
+    const row = lines[1].split(",");
+    expect(row[0]).toBe("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11");
+    expect(row[2]).toBe("2024-01-15");
+    expect(row[5]).toBe("720");
+    expect(row[9]).toBe("170");
+  });
+
+  it("null フィールドは空文字列になる", () => {
+    const csv = roastLogsToCSV([BASE_LOG]);
+    const row = csv.split("\n")[1].split(",");
+    const headers = csv.split("\n")[0].split(",");
+    const roastDeviceIdx = headers.indexOf("roastDeviceId");
+    const secondCrackIdx = headers.indexOf("secondCrackSec");
+    const indoorTempIdx = headers.indexOf("indoorTempC");
+    expect(row[roastDeviceIdx]).toBe("");
+    expect(row[secondCrackIdx]).toBe("");
+    expect(row[indoorTempIdx]).toBe("");
+  });
+
+  it("tasting が null の場合は全 tasting_ フィールドが空文字列", () => {
+    const log: RoastLog = { ...BASE_LOG, tasting: null };
+    const csv = roastLogsToCSV([log]);
+    const headers = csv.split("\n")[0].split(",");
+    const row = csv.split("\n")[1].split(",");
+    for (const h of headers.filter((h) => h.startsWith("tasting_"))) {
+      expect(row[headers.indexOf(h)]).toBe("");
+    }
+  });
+
+  it("flavorTags は CSV エスケープされた JSON 文字列でシリアライズされる", () => {
+    const csv = roastLogsToCSV([BASE_LOG]);
+    expect(csv).toContain('"[""fruity"",""chocolate""]"');
+  });
+
+  it("processNote にカンマが含まれる場合はダブルクォートでエスケープされる", () => {
+    const log: RoastLog = { ...BASE_LOG, processNote: "熱い,良い感じ" };
+    const csv = roastLogsToCSV([log]);
+    expect(csv).toContain('"熱い,良い感じ"');
+  });
+
+  it("複数件を正しく出力する", () => {
+    const log2: RoastLog = {
+      ...BASE_LOG,
+      id: "c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    };
+    const csv = roastLogsToCSV([BASE_LOG, log2]);
+    const lines = csv.split("\n");
+    expect(lines).toHaveLength(3);
+  });
+});

--- a/src/lib/csvExport.ts
+++ b/src/lib/csvExport.ts
@@ -1,0 +1,81 @@
+import type { RoastLog } from "@/schemas/roastLog";
+
+const HEADERS = [
+  "id",
+  "beanId",
+  "roastDate",
+  "roastLevelId",
+  "roastDeviceId",
+  "roastDurationSec",
+  "firstCrackSec",
+  "secondCrackSec",
+  "weightBeforeG",
+  "weightAfterG",
+  "outdoorTempC",
+  "outdoorHumidity",
+  "indoorTempC",
+  "tempSource",
+  "weatherCode",
+  "tasting_flavorTags",
+  "tasting_sweetness",
+  "tasting_acidity",
+  "tasting_body",
+  "tasting_bitterness",
+  "tasting_aftertaste",
+  "tasting_cleanliness",
+  "overallScore",
+  "processNote",
+] as const;
+
+function escapeCell(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function serializeRow(log: RoastLog): string {
+  const cells: string[] = [
+    log.id,
+    log.beanId,
+    log.roastDate,
+    log.roastLevelId,
+    log.roastDeviceId ?? "",
+    String(log.roastDurationSec),
+    log.firstCrackSec != null ? String(log.firstCrackSec) : "",
+    log.secondCrackSec != null ? String(log.secondCrackSec) : "",
+    String(log.weightBeforeG),
+    String(log.weightAfterG),
+    log.outdoorTempC != null ? String(log.outdoorTempC) : "",
+    log.outdoorHumidity != null ? String(log.outdoorHumidity) : "",
+    log.indoorTempC != null ? String(log.indoorTempC) : "",
+    log.tempSource,
+    log.weatherCode != null ? String(log.weatherCode) : "",
+    log.tasting != null ? JSON.stringify(log.tasting.flavorTags) : "",
+    log.tasting != null ? String(log.tasting.sweetness) : "",
+    log.tasting != null ? String(log.tasting.acidity) : "",
+    log.tasting != null ? String(log.tasting.body) : "",
+    log.tasting != null ? String(log.tasting.bitterness) : "",
+    log.tasting != null ? String(log.tasting.aftertaste) : "",
+    log.tasting != null ? String(log.tasting.cleanliness) : "",
+    log.overallScore != null ? String(log.overallScore) : "",
+    log.processNote,
+  ];
+  return cells.map(escapeCell).join(",");
+}
+
+export function roastLogsToCSV(logs: RoastLog[]): string {
+  const rows = [HEADERS.join(","), ...logs.map(serializeRow)];
+  return rows.join("\n");
+}
+
+export function downloadCSV(csv: string, filename: string): void {
+  const bom = "﻿";
+  const blob = new Blob([bom + csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/lib/csvImport.test.ts
+++ b/src/lib/csvImport.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { roastLogsToCSV } from "@/lib/csvExport";
+import { mergeImport, parseRoastLogCSV } from "@/lib/csvImport";
+import type { RoastLog } from "@/schemas/roastLog";
+
+const SAMPLE_LOG: RoastLog = {
+  id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+  beanId: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+  roastDate: "2024-01-15",
+  roastLevelId: "medium",
+  roastDeviceId: null,
+  roastDurationSec: 720,
+  firstCrackSec: 480,
+  secondCrackSec: null,
+  weightBeforeG: 200,
+  weightAfterG: 170,
+  outdoorTempC: 15.5,
+  outdoorHumidity: 60,
+  indoorTempC: null,
+  tempSource: "auto",
+  weatherCode: 0,
+  tasting: {
+    flavorTags: ["fruity", "chocolate"],
+    sweetness: 4,
+    acidity: 3,
+    body: 3,
+    bitterness: 2,
+    aftertaste: 4,
+    cleanliness: 5,
+  },
+  overallScore: 4,
+  processNote: "順調",
+};
+
+describe("parseRoastLogCSV", () => {
+  it("正常な CSV をパースして ok: true と rows を返す", () => {
+    const csv = roastLogsToCSV([SAMPLE_LOG]);
+    const result = parseRoastLogCSV(csv);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toEqual(SAMPLE_LOG);
+  });
+
+  it("tasting が null の RoastLog をラウンドトリップできる", () => {
+    const log: RoastLog = { ...SAMPLE_LOG, tasting: null, overallScore: null };
+    const csv = roastLogsToCSV([log]);
+    const result = parseRoastLogCSV(csv);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rows[0]).toEqual(log);
+  });
+
+  it("processNote にカンマを含む RoastLog をラウンドトリップできる", () => {
+    const log: RoastLog = { ...SAMPLE_LOG, processNote: "熱い,良い感じ" };
+    const csv = roastLogsToCSV([log]);
+    const result = parseRoastLogCSV(csv);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rows[0].processNote).toBe("熱い,良い感じ");
+  });
+
+  it("複数件をラウンドトリップできる", () => {
+    const log2: RoastLog = {
+      ...SAMPLE_LOG,
+      id: "e0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    };
+    const csv = roastLogsToCSV([SAMPLE_LOG, log2]);
+    const result = parseRoastLogCSV(csv);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rows).toHaveLength(2);
+  });
+
+  it("ヘッダー行が欠けている場合は ok: false を返す", () => {
+    const result = parseRoastLogCSV("");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/ヘッダー/);
+  });
+
+  it("必須ヘッダーが不足している場合は ok: false を返す", () => {
+    const csv = "id,beanId\n11111111-1111-1111-1111-111111111111,22222222";
+    const result = parseRoastLogCSV(csv);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/ヘッダー/);
+  });
+
+  it("データ行が Zod スキーマに違反する場合は ok: false を返す", () => {
+    const csv = roastLogsToCSV([SAMPLE_LOG]).split("\n");
+    // id を UUID でない値に書き換える
+    csv[1] = csv[1].replace(SAMPLE_LOG.id, "not-a-uuid");
+    const result = parseRoastLogCSV(csv.join("\n"));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/行 2/);
+  });
+});
+
+describe("mergeImport", () => {
+  const existing: RoastLog[] = [SAMPLE_LOG];
+  const updated: RoastLog = { ...SAMPLE_LOG, processNote: "更新後" };
+
+  it("overwrite モードで重複 ID のレコードを上書きする", () => {
+    const result = mergeImport([updated], existing, "overwrite");
+    expect(result).toHaveLength(1);
+    expect(result[0].processNote).toBe("更新後");
+  });
+
+  it("skip モードで重複 ID のレコードをスキップする", () => {
+    const result = mergeImport([updated], existing, "skip");
+    expect(result).toHaveLength(1);
+    expect(result[0].processNote).toBe("順調");
+  });
+
+  it("新規 ID のレコードはどちらのモードでも追加される", () => {
+    const newLog: RoastLog = {
+      ...SAMPLE_LOG,
+      id: "c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    };
+    const resultOverwrite = mergeImport([newLog], existing, "overwrite");
+    const resultSkip = mergeImport([newLog], existing, "skip");
+    expect(resultOverwrite).toHaveLength(2);
+    expect(resultSkip).toHaveLength(2);
+  });
+
+  it("既存データに存在しない incoming レコードは末尾に追加される", () => {
+    const newLog: RoastLog = {
+      ...SAMPLE_LOG,
+      id: "d0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    };
+    const result = mergeImport([newLog], existing, "skip");
+    expect(result[result.length - 1].id).toBe(newLog.id);
+  });
+});

--- a/src/lib/csvImport.ts
+++ b/src/lib/csvImport.ts
@@ -122,13 +122,42 @@ function deserializeRow(headers: string[], cells: string[]): unknown {
   };
 }
 
+function splitCSVRows(text: string): string[] {
+  const rows: string[] = [];
+  let row = "";
+  let inQuote = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '"') {
+      if (inQuote && text[i + 1] === '"') {
+        row += '""';
+        i++;
+        continue;
+      }
+      inQuote = !inQuote;
+      row += ch;
+      continue;
+    }
+    if (!inQuote && (ch === "\n" || ch === "\r")) {
+      if (ch === "\r" && text[i + 1] === "\n") i++;
+      if (row.trim() !== "") rows.push(row);
+      row = "";
+      continue;
+    }
+    row += ch;
+  }
+  if (row.trim() !== "") rows.push(row);
+  return rows;
+}
+
 export function parseRoastLogCSV(text: string): ParseResult {
-  const lines = text.split("\n").filter((l) => l.trim() !== "");
+  const lines = splitCSVRows(text);
   if (lines.length === 0) {
     return { ok: false, error: "ヘッダー行がありません" };
   }
 
-  const headers = parseCSVLine(lines[0]);
+  const headerLine = lines[0].replace(/^﻿/, "").replace(/\r$/, "");
+  const headers = parseCSVLine(headerLine);
   const missing = REQUIRED_HEADERS.filter((h) => !headers.includes(h));
   if (missing.length > 0) {
     return {

--- a/src/lib/csvImport.ts
+++ b/src/lib/csvImport.ts
@@ -1,0 +1,169 @@
+import {
+  type RoastLog,
+  RoastLogSchema,
+  TastingSchema,
+} from "@/schemas/roastLog";
+
+export type ParseResult =
+  | { ok: true; rows: RoastLog[] }
+  | { ok: false; error: string };
+
+const REQUIRED_HEADERS = [
+  "id",
+  "beanId",
+  "roastDate",
+  "roastLevelId",
+  "roastDeviceId",
+  "roastDurationSec",
+  "firstCrackSec",
+  "secondCrackSec",
+  "weightBeforeG",
+  "weightAfterG",
+  "outdoorTempC",
+  "outdoorHumidity",
+  "indoorTempC",
+  "tempSource",
+  "weatherCode",
+  "tasting_flavorTags",
+  "tasting_sweetness",
+  "tasting_acidity",
+  "tasting_body",
+  "tasting_bitterness",
+  "tasting_aftertaste",
+  "tasting_cleanliness",
+  "overallScore",
+  "processNote",
+];
+
+function parseCSVLine(line: string): string[] {
+  const cells: string[] = [];
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] === '"') {
+      // quoted cell
+      let cell = "";
+      i++; // skip opening quote
+      while (i < line.length) {
+        if (line[i] === '"' && line[i + 1] === '"') {
+          cell += '"';
+          i += 2;
+        } else if (line[i] === '"') {
+          i++; // skip closing quote
+          break;
+        } else {
+          cell += line[i];
+          i++;
+        }
+      }
+      cells.push(cell);
+      if (line[i] === ",") i++;
+    } else {
+      const end = line.indexOf(",", i);
+      if (end === -1) {
+        cells.push(line.slice(i));
+        break;
+      }
+      cells.push(line.slice(i, end));
+      i = end + 1;
+    }
+  }
+  return cells;
+}
+
+function toNum(s: string): number {
+  return Number(s);
+}
+
+function toNumOrNull(s: string): number | null {
+  return s === "" ? null : Number(s);
+}
+
+function toStrOrNull(s: string): string | null {
+  return s === "" ? null : s;
+}
+
+function deserializeRow(headers: string[], cells: string[]): unknown {
+  const get = (h: string) => cells[headers.indexOf(h)] ?? "";
+
+  const tastingFlavorTagsRaw = get("tasting_flavorTags");
+  const hasTasting = tastingFlavorTagsRaw !== "";
+
+  const tasting = hasTasting
+    ? TastingSchema.parse({
+        flavorTags: JSON.parse(tastingFlavorTagsRaw),
+        sweetness: toNum(get("tasting_sweetness")),
+        acidity: toNum(get("tasting_acidity")),
+        body: toNum(get("tasting_body")),
+        bitterness: toNum(get("tasting_bitterness")),
+        aftertaste: toNum(get("tasting_aftertaste")),
+        cleanliness: toNum(get("tasting_cleanliness")),
+      })
+    : null;
+
+  return {
+    id: get("id"),
+    beanId: get("beanId"),
+    roastDate: get("roastDate"),
+    roastLevelId: get("roastLevelId"),
+    roastDeviceId: toStrOrNull(get("roastDeviceId")),
+    roastDurationSec: toNum(get("roastDurationSec")),
+    firstCrackSec: toNumOrNull(get("firstCrackSec")),
+    secondCrackSec: toNumOrNull(get("secondCrackSec")),
+    weightBeforeG: toNum(get("weightBeforeG")),
+    weightAfterG: toNum(get("weightAfterG")),
+    outdoorTempC: toNumOrNull(get("outdoorTempC")),
+    outdoorHumidity: toNumOrNull(get("outdoorHumidity")),
+    indoorTempC: toNumOrNull(get("indoorTempC")),
+    tempSource: get("tempSource"),
+    weatherCode: toNumOrNull(get("weatherCode")),
+    tasting,
+    overallScore: toNumOrNull(get("overallScore")),
+    processNote: get("processNote"),
+  };
+}
+
+export function parseRoastLogCSV(text: string): ParseResult {
+  const lines = text.split("\n").filter((l) => l.trim() !== "");
+  if (lines.length === 0) {
+    return { ok: false, error: "ヘッダー行がありません" };
+  }
+
+  const headers = parseCSVLine(lines[0]);
+  const missing = REQUIRED_HEADERS.filter((h) => !headers.includes(h));
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      error: `ヘッダーが不足しています: ${missing.join(", ")}`,
+    };
+  }
+
+  const rows: RoastLog[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cells = parseCSVLine(lines[i]);
+    try {
+      const raw = deserializeRow(headers, cells);
+      rows.push(RoastLogSchema.parse(raw));
+    } catch (e) {
+      return {
+        ok: false,
+        error: `行 ${i + 1} のデータが不正です: ${String(e)}`,
+      };
+    }
+  }
+
+  return { ok: true, rows };
+}
+
+export function mergeImport(
+  incoming: RoastLog[],
+  existing: RoastLog[],
+  mode: "overwrite" | "skip",
+): RoastLog[] {
+  const map = new Map(existing.map((r) => [r.id, r]));
+  for (const row of incoming) {
+    if (mode === "overwrite" || !map.has(row.id)) {
+      map.set(row.id, row);
+    }
+  }
+  return Array.from(map.values());
+}


### PR DESCRIPTION
## Summary

- `src/domain/roastLog.ts` に `filterAndSortLogs` 純関数を追加。5種フィルター（bean / roastLevel / roastDevice / score範囲 / 日付範囲）× 3ソートキー（roastDate / overallScore / weightLossRate）× 2方向（asc/desc）に対応
- `RoastLogListPage` にフィルターチップ展開パネル（チップ押下でインライン表示）とヘッダーソートセレクトを実装
- `filterAndSortLogs` の旧 `sorted` ロジックを置き換え、TODO コメントを解消

## Closes

Closes #11

## Test plan

- [x] `filterAndSortLogs` ユニットテスト 18件（全フィルター・ソート条件、組み合わせ）
- [x] `RoastLogListPage` ブラウザテスト 2件追加（豆フィルター適用、ソート切り替え）
- [x] 全 196 テスト通過
- [x] pre-commit hook（biome / tsc / arch:check）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ロースティングログを CSV 形式でエクスポートできるようになりました
  * CSV ファイルからロースティングログをインポート可能になりました（上書き/スキップモードに対応）
  * 豆の種類、ロースティングレベル、使用デバイス、スコア範囲、日付範囲による詳細フィルタリング機能を追加しました
  * 日付、スコア、重量減少率による並べ替え機能を追加しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otufor/RoastLog/pull/30)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->