### PR TITLE
fix(RoastLogForm): pass items prop to Select to show label instead of UUID

### DIFF
--- a/src/components/RoastLogForm.tsx
+++ b/src/components/RoastLogForm.tsx
@@ -171,6 +171,7 @@ export function RoastLogForm({
             <Select
               value={field.state.value || null}
               onValueChange={(v) => field.handleChange(v ?? "")}
+              items={beans.map((b) => ({ value: b.id, label: b.name }))}
             >
               <SelectTrigger id="log-bean-id" className="w-full">
                 <SelectValue placeholder="豆を選択" />
@@ -234,6 +235,7 @@ export function RoastLogForm({
             <Select
               value={field.state.value || null}
               onValueChange={(v) => field.handleChange(v ?? "")}
+              items={roastLevels.map((l) => ({ value: l.id, label: l.label }))}
             >
               <SelectTrigger id="log-roast-level-id" className="w-full">
                 <SelectValue placeholder="焙煎度を選択" />
@@ -271,6 +273,10 @@ export function RoastLogForm({
             <Select
               value={field.state.value ?? undefined}
               onValueChange={(v) => field.handleChange(v === "" ? null : v)}
+              items={[
+                { value: "", label: "なし" },
+                ...roastDevices.map((d) => ({ value: d.id, label: d.name })),
+              ]}
             >
               <SelectTrigger id="log-roast-device-id" className="w-full">
                 <SelectValue placeholder="なし" />


### PR DESCRIPTION
## Summary

- Base UI v1.4 の `Select.Value` は `items` prop がないと UUID をそのまま表示する
- 豆・焙煎度・焙煎機の3セレクトに `items={[{ value, label }]}` を追加
- 選択後にユーザー向けの名前が正しく表示されるようになる

## Test plan

- [ ] 焙煎ログ登録フォームで豆を選択 → 豆名が表示されることを確認
- [ ] 焙煎ログ登録フォームで焙煎度を選択 → ラベルが表示されることを確認
- [ ] 焙煎ログ登録フォームで焙煎機を選択 → 機器名が表示されることを確認
- [ ] 焙煎ログ編集フォームでも同様に確認

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)