### PR TITLE
feat(security): gitleaks を pre-commit フックに統合 (#42)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,4 @@
+title = "RoastLog gitleaks config"
+
+[extend]
+useDefault = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,31 @@ npx vitest run --project unit src/schemas/bean.test.ts
 npx vitest run --project browser src/repositories/beanRepository.test.ts
 ```
 
-Pre-commit hook (lefthook) runs `biome check`, `tsc --noEmit`, and `arch:check` in parallel automatically.
+Pre-commit hook (lefthook) runs `biome check`, `tsc --noEmit`, `arch:check`, and `gitleaks protect --staged` in parallel automatically.
+
+### Local setup: gitleaks
+
+gitleaks はシークレット漏洩を検知する pre-commit ツールです。初回セットアップ時にインストールしてください。
+
+```bash
+# WSL / Linux（推奨）— /usr/local/bin に配置（hooks の最小 PATH で確実に見つかる）
+GITLEAKS_VERSION=$(curl -s "https://api.github.com/repos/gitleaks/gitleaks/releases/latest" \
+  | grep -Po '"tag_name": "v\K[0-9.]+')
+wget -qO gitleaks.tar.gz \
+  "https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+tar -xzf gitleaks.tar.gz gitleaks
+sudo mv gitleaks /usr/local/bin/
+rm gitleaks.tar.gz
+gitleaks version
+
+# macOS
+brew install gitleaks
+
+# Windows
+winget install gitleaks.gitleaks
+```
+
+> **WSL 注意**: git hooks は最小 PATH で実行されるため、`lefthook.yml` では絶対パス `/usr/local/bin/gitleaks` を使っています。`which gitleaks` で確認してください。
 
 ## Architecture
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,3 +9,12 @@ pre-commit:
 
     - name: arch
       run: npm run arch:check
+
+    - name: gitleaks
+      run: /usr/local/bin/gitleaks protect --staged --redact --config .gitleaks.toml
+      fail_text: |
+        gitleaks がインストールされていません。
+        インストール方法:
+          WSL/Linux: https://github.com/gitleaks/gitleaks#installing
+          macOS:     brew install gitleaks
+          Windows:   winget install gitleaks.gitleaks


### PR DESCRIPTION
## Summary

- `lefthook.yml` に gitleaks ジョブを追加（`/usr/local/bin/gitleaks protect --staged --redact --config .gitleaks.toml`）
- WSL hooks の最小 PATH 問題に対応するため絶対パスを使用
- `.gitleaks.toml` を新規作成（`useDefault = true` でデフォルトルールセット適用）
- `AGENTS.md` に WSL/Linux・macOS・Windows のインストール手順を追記

## Test plan

- [ ] gitleaks をインストール後、`git commit` 時に `gitleaks protect --staged` が実行されることを確認
- [ ] ダミーのシークレット（例: `AWS_SECRET_ACCESS_KEY=wJalrXUt...`）をステージしてコミットするとブロックされることを確認
- [ ] 既存の pre-commit ジョブ（lint・typecheck・arch）が引き続き正常に動作することを確認
- [ ] `npm run build` および `npm run test:run` がエラーなく完了することを確認

Closes #42

🤖 Generated with [Claude Code](https://claude.ai/claude-code)