### PR TITLE
feat(settings): 焙煎度・フレーバータグセクションをデフォルト折りたたみに

### DIFF
--- a/src/components/FlavorTagSettings.test.tsx
+++ b/src/components/FlavorTagSettings.test.tsx
@@ -14,6 +14,12 @@ function renderSection() {
   );
 }
 
+async function expand() {
+  await userEvent.click(
+    screen.getByRole("button", { name: "フレーバータグを展開" }),
+  );
+}
+
 describe("FlavorTagSettings", () => {
   beforeEach(async () => {
     await Promise.all([
@@ -25,6 +31,38 @@ describe("FlavorTagSettings", () => {
     ]);
   });
 
+  it("デフォルトで折りたたまれており、リストと追加ボタンが非表示", () => {
+    renderSection();
+    expect(
+      screen.queryByRole("button", { name: "フレーバータグを追加" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "フレーバータグを展開" }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("展開ボタンをクリックするとコンテンツが表示される", async () => {
+    renderSection();
+    await expand();
+    expect(
+      screen.getByRole("button", { name: "フレーバータグを追加" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "フレーバータグを折りたたむ" }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("展開後に再クリックすると折りたたまれる", async () => {
+    renderSection();
+    await expand();
+    await userEvent.click(
+      screen.getByRole("button", { name: "フレーバータグを折りたたむ" }),
+    );
+    expect(
+      screen.queryByRole("button", { name: "フレーバータグを追加" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("登録済み FlavorTag を一覧表示する", async () => {
     await db.flavorTags.add({
       id: "a",
@@ -32,6 +70,7 @@ describe("FlavorTagSettings", () => {
       color: "#F9A8D4",
     });
     renderSection();
+    await expand();
     await waitFor(() =>
       expect(screen.getByText("フローラル")).toBeInTheDocument(),
     );
@@ -40,6 +79,7 @@ describe("FlavorTagSettings", () => {
   it("「追加」ボタンから新規作成できる", async () => {
     const user = userEvent.setup();
     renderSection();
+    await expand();
 
     await user.click(
       screen.getByRole("button", { name: "フレーバータグを追加" }),
@@ -59,6 +99,7 @@ describe("FlavorTagSettings", () => {
 
     const user = userEvent.setup();
     renderSection();
+    await expand();
     await waitFor(() =>
       expect(screen.getByText("フローラル")).toBeInTheDocument(),
     );
@@ -81,6 +122,7 @@ describe("FlavorTagSettings", () => {
   it("名前が空の場合は保存されない", async () => {
     const user = userEvent.setup();
     renderSection();
+    await expand();
 
     await user.click(
       screen.getByRole("button", { name: "フレーバータグを追加" }),
@@ -101,6 +143,7 @@ describe("FlavorTagSettings", () => {
 
     const user = userEvent.setup();
     renderSection();
+    await expand();
     await waitFor(() => expect(screen.getByText("ナッツ")).toBeInTheDocument());
 
     const item = screen.getByRole("listitem");

--- a/src/components/FlavorTagSettings.tsx
+++ b/src/components/FlavorTagSettings.tsx
@@ -1,4 +1,5 @@
 import { useForm } from "@tanstack/react-form";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -25,73 +26,100 @@ export function FlavorTagSettings() {
   const update = useUpdateFlavorTag();
   const del = useDeleteFlavorTag();
   const [draft, setDraft] = useState<Draft>(null);
+  const [collapsed, setCollapsed] = useState(true);
 
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-semibold">フレーバータグ</h2>
-        <Button onClick={() => setDraft({ mode: "create" })}>
-          フレーバータグを追加
-        </Button>
+        <button
+          type="button"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-expanded={!collapsed}
+          aria-controls="flavor-tag-content"
+          aria-label={
+            collapsed ? "フレーバータグを展開" : "フレーバータグを折りたたむ"
+          }
+          className="rounded p-1 hover:bg-muted"
+        >
+          {collapsed ? (
+            <ChevronDown className="h-5 w-5" />
+          ) : (
+            <ChevronUp className="h-5 w-5" />
+          )}
+        </button>
       </div>
 
-      {draft && (
-        <div
-          role="dialog"
-          aria-labelledby="flavor-tag-dialog-title"
-          className="rounded-lg border bg-muted/30 p-4"
-        >
-          <h3 id="flavor-tag-dialog-title" className="mb-3 font-medium">
-            {draft.mode === "edit"
-              ? "フレーバータグを編集"
-              : "フレーバータグを追加"}
-          </h3>
-          <FlavorTagForm
-            key={draft.mode === "edit" ? draft.tag.id : "new"}
-            defaultValues={draft.mode === "edit" ? draft.tag : empty}
-            onSubmit={async (input) => {
-              if (draft.mode === "edit") {
-                await update.mutateAsync({ ...draft.tag, ...input });
-              } else {
-                await create.mutateAsync(input);
-              }
-              setDraft(null);
-            }}
-            onCancel={() => setDraft(null)}
-          />
-        </div>
-      )}
+      <div id="flavor-tag-content">
+        {!collapsed && (
+          <>
+            <Button onClick={() => setDraft({ mode: "create" })}>
+              フレーバータグを追加
+            </Button>
 
-      {tags?.length === 0 ? (
-        <p className="text-muted-foreground">
-          フレーバータグが登録されていません
-        </p>
-      ) : (
-        <ul className="flex flex-col gap-2">
-          {tags?.map((tag) => (
-            <li
-              key={tag.id}
-              className="flex items-center gap-3 rounded-lg border p-3"
-            >
-              <span
-                aria-hidden
-                className="inline-block h-4 w-4 rounded-full"
-                style={{ background: tag.color }}
-              />
-              <span className="flex-1">{tag.name}</span>
-              <Button
-                variant="outline"
-                onClick={() => setDraft({ mode: "edit", tag })}
+            {draft && (
+              <div
+                role="dialog"
+                aria-labelledby="flavor-tag-dialog-title"
+                className="rounded-lg border bg-muted/30 p-4"
               >
-                編集
-              </Button>
-              <Button variant="destructive" onClick={() => del.mutate(tag.id)}>
-                削除
-              </Button>
-            </li>
-          ))}
-        </ul>
-      )}
+                <h3 id="flavor-tag-dialog-title" className="mb-3 font-medium">
+                  {draft.mode === "edit"
+                    ? "フレーバータグを編集"
+                    : "フレーバータグを追加"}
+                </h3>
+                <FlavorTagForm
+                  key={draft.mode === "edit" ? draft.tag.id : "new"}
+                  defaultValues={draft.mode === "edit" ? draft.tag : empty}
+                  onSubmit={async (input) => {
+                    if (draft.mode === "edit") {
+                      await update.mutateAsync({ ...draft.tag, ...input });
+                    } else {
+                      await create.mutateAsync(input);
+                    }
+                    setDraft(null);
+                  }}
+                  onCancel={() => setDraft(null)}
+                />
+              </div>
+            )}
+
+            {tags?.length === 0 ? (
+              <p className="text-muted-foreground">
+                フレーバータグが登録されていません
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {tags?.map((tag) => (
+                  <li
+                    key={tag.id}
+                    className="flex items-center gap-3 rounded-lg border p-3"
+                  >
+                    <span
+                      aria-hidden
+                      className="inline-block h-4 w-4 rounded-full"
+                      style={{ background: tag.color }}
+                    />
+                    <span className="flex-1">{tag.name}</span>
+                    <Button
+                      variant="outline"
+                      onClick={() => setDraft({ mode: "edit", tag })}
+                    >
+                      編集
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      onClick={() => del.mutate(tag.id)}
+                    >
+                      削除
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+      </div>
     </section>
   );
 }

--- a/src/components/RoastLevelSettings.test.tsx
+++ b/src/components/RoastLevelSettings.test.tsx
@@ -14,6 +14,10 @@ function renderSection() {
   );
 }
 
+async function expand() {
+  await userEvent.click(screen.getByRole("button", { name: "焙煎度を展開" }));
+}
+
 describe("RoastLevelSettings", () => {
   beforeEach(async () => {
     await Promise.all([
@@ -25,6 +29,38 @@ describe("RoastLevelSettings", () => {
     ]);
   });
 
+  it("デフォルトで折りたたまれており、リストと追加ボタンが非表示", () => {
+    renderSection();
+    expect(
+      screen.queryByRole("button", { name: "焙煎度を追加" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "焙煎度を展開" }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("展開ボタンをクリックするとコンテンツが表示される", async () => {
+    renderSection();
+    await expand();
+    expect(
+      screen.getByRole("button", { name: "焙煎度を追加" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "焙煎度を折りたたむ" }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("展開後に再クリックすると折りたたまれる", async () => {
+    renderSection();
+    await expand();
+    await userEvent.click(
+      screen.getByRole("button", { name: "焙煎度を折りたたむ" }),
+    );
+    expect(
+      screen.queryByRole("button", { name: "焙煎度を追加" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("登録済み RoastLevel を order 順で表示する", async () => {
     await db.roastLevels.bulkAdd([
       { id: "a", label: "深煎り", color: "#3E1A06", order: 5 },
@@ -32,6 +68,7 @@ describe("RoastLevelSettings", () => {
     ]);
 
     renderSection();
+    await expand();
 
     await waitFor(() => expect(screen.getByText("浅煎り")).toBeInTheDocument());
     const items = screen.getAllByRole("listitem");
@@ -42,6 +79,7 @@ describe("RoastLevelSettings", () => {
   it("「追加」ボタンから新しい RoastLevel を作成できる", async () => {
     const user = userEvent.setup();
     renderSection();
+    await expand();
 
     await user.click(screen.getByRole("button", { name: "焙煎度を追加" }));
 
@@ -66,6 +104,7 @@ describe("RoastLevelSettings", () => {
 
     const user = userEvent.setup();
     renderSection();
+    await expand();
     await waitFor(() => expect(screen.getByText("中煎り")).toBeInTheDocument());
 
     const item = screen.getByRole("listitem");
@@ -86,6 +125,7 @@ describe("RoastLevelSettings", () => {
   it("ラベルが空の場合は保存されない", async () => {
     const user = userEvent.setup();
     renderSection();
+    await expand();
 
     await user.click(screen.getByRole("button", { name: "焙煎度を追加" }));
     const dialog = await screen.findByRole("dialog");
@@ -106,6 +146,7 @@ describe("RoastLevelSettings", () => {
 
     const user = userEvent.setup();
     renderSection();
+    await expand();
     await waitFor(() => expect(screen.getByText("中煎り")).toBeInTheDocument());
 
     const item = screen.getByRole("listitem");

--- a/src/components/RoastLevelSettings.tsx
+++ b/src/components/RoastLevelSettings.tsx
@@ -1,4 +1,5 @@
 import { useForm } from "@tanstack/react-form";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -25,75 +26,99 @@ export function RoastLevelSettings() {
   const update = useUpdateRoastLevel();
   const del = useDeleteRoastLevel();
   const [draft, setDraft] = useState<Draft>(null);
+  const [collapsed, setCollapsed] = useState(true);
 
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-semibold">焙煎度</h2>
-        <Button onClick={() => setDraft({ mode: "create" })}>
-          焙煎度を追加
-        </Button>
+        <button
+          type="button"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-expanded={!collapsed}
+          aria-controls="roast-level-content"
+          aria-label={collapsed ? "焙煎度を展開" : "焙煎度を折りたたむ"}
+          className="rounded p-1 hover:bg-muted"
+        >
+          {collapsed ? (
+            <ChevronDown className="h-5 w-5" />
+          ) : (
+            <ChevronUp className="h-5 w-5" />
+          )}
+        </button>
       </div>
 
-      {draft && (
-        <div
-          role="dialog"
-          aria-labelledby="roast-level-dialog-title"
-          className="rounded-lg border bg-muted/30 p-4"
-        >
-          <h3 id="roast-level-dialog-title" className="mb-3 font-medium">
-            {draft.mode === "edit" ? "焙煎度を編集" : "焙煎度を追加"}
-          </h3>
-          <RoastLevelForm
-            key={draft.mode === "edit" ? draft.level.id : "new"}
-            defaultValues={draft.mode === "edit" ? draft.level : empty}
-            onSubmit={async (input) => {
-              if (draft.mode === "edit") {
-                await update.mutateAsync({ ...draft.level, ...input });
-              } else {
-                await create.mutateAsync(input);
-              }
-              setDraft(null);
-            }}
-            onCancel={() => setDraft(null)}
-          />
-        </div>
-      )}
+      <div id="roast-level-content">
+        {!collapsed && (
+          <>
+            <Button onClick={() => setDraft({ mode: "create" })}>
+              焙煎度を追加
+            </Button>
 
-      {levels?.length === 0 ? (
-        <p className="text-muted-foreground">焙煎度が登録されていません</p>
-      ) : (
-        <ul className="flex flex-col gap-2">
-          {levels?.map((level) => (
-            <li
-              key={level.id}
-              className="flex items-center gap-3 rounded-lg border p-3"
-            >
-              <span
-                aria-hidden
-                className="inline-block h-4 w-4 rounded-full"
-                style={{ background: level.color }}
-              />
-              <span className="flex-1">{level.label}</span>
-              <span className="text-sm text-muted-foreground">
-                順: {level.order}
-              </span>
-              <Button
-                variant="outline"
-                onClick={() => setDraft({ mode: "edit", level })}
+            {draft && (
+              <div
+                role="dialog"
+                aria-labelledby="roast-level-dialog-title"
+                className="rounded-lg border bg-muted/30 p-4"
               >
-                編集
-              </Button>
-              <Button
-                variant="destructive"
-                onClick={() => del.mutate(level.id)}
-              >
-                削除
-              </Button>
-            </li>
-          ))}
-        </ul>
-      )}
+                <h3 id="roast-level-dialog-title" className="mb-3 font-medium">
+                  {draft.mode === "edit" ? "焙煎度を編集" : "焙煎度を追加"}
+                </h3>
+                <RoastLevelForm
+                  key={draft.mode === "edit" ? draft.level.id : "new"}
+                  defaultValues={draft.mode === "edit" ? draft.level : empty}
+                  onSubmit={async (input) => {
+                    if (draft.mode === "edit") {
+                      await update.mutateAsync({ ...draft.level, ...input });
+                    } else {
+                      await create.mutateAsync(input);
+                    }
+                    setDraft(null);
+                  }}
+                  onCancel={() => setDraft(null)}
+                />
+              </div>
+            )}
+
+            {levels?.length === 0 ? (
+              <p className="text-muted-foreground">
+                焙煎度が登録されていません
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {levels?.map((level) => (
+                  <li
+                    key={level.id}
+                    className="flex items-center gap-3 rounded-lg border p-3"
+                  >
+                    <span
+                      aria-hidden
+                      className="inline-block h-4 w-4 rounded-full"
+                      style={{ background: level.color }}
+                    />
+                    <span className="flex-1">{level.label}</span>
+                    <span className="text-sm text-muted-foreground">
+                      順: {level.order}
+                    </span>
+                    <Button
+                      variant="outline"
+                      onClick={() => setDraft({ mode: "edit", level })}
+                    >
+                      編集
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      onClick={() => del.mutate(level.id)}
+                    >
+                      削除
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- 設定ページの「焙煎度」「フレーバータグ」セクションにアコーディオン UI を追加（closes #45）
- デフォルト折りたたみ（`collapsed = true`）、ChevronDown/Up アイコンでトグル
- `aria-expanded` + `aria-controls` + `aria-label` でアクセシブルに対応

## Test plan

- [x] `RoastLevelSettings` — デフォルト折りたたみ／展開／再折りたたみの3テストを新規追加
- [x] `FlavorTagSettings` — 同上3テストを新規追加
- [x] 既存 CRUD テスト（各5件）に展開ステップを追加して全件パスを確認
- [x] pre-commit フック（lint / typecheck / arch:check）全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フレーバータグ設定セクションを折りたたみ可能に改善しました。初期状態では折りたたまれており、ヘッダーのボタンで展開・折りたたみを切り替えられます。
  * 焙煎度設定セクションを折りたたみ可能に改善しました。初期状態では折りたたまれており、ヘッダーのボタンで展開・折りたたみを切り替えられます。

* **テスト**
  * 折りたたみ機能の動作検証テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otufor/RoastLog/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->