### PR TITLE
refactor(settings): 設定画面デザイン刷新（#49-#53）

### DIFF
--- a/src/components/CsvSection.tsx
+++ b/src/components/CsvSection.tsx
@@ -46,9 +46,7 @@ export function CsvSection() {
   }
 
   return (
-    <section className="flex flex-col gap-4">
-      <h2 className="text-xl font-semibold">データ管理</h2>
-
+    <div className="flex flex-col gap-4 p-4">
       <div className="flex flex-col gap-2">
         <button
           type="button"
@@ -115,6 +113,6 @@ export function CsvSection() {
         )}
         {success && <p className="text-sm text-green-600">{success}</p>}
       </div>
-    </section>
+    </div>
   );
 }

--- a/src/components/FlavorTagSettings.test.tsx
+++ b/src/components/FlavorTagSettings.test.tsx
@@ -135,10 +135,13 @@ describe("FlavorTagSettings", () => {
     await waitFor(() => expect(screen.getByText("ベリー")).toBeInTheDocument());
     expect(screen.getByText("シトラス")).toBeInTheDocument();
 
-    // 各ピルに aria-hidden な色ドットが含まれる
-    const dots = document.querySelectorAll(
-      "[aria-hidden='true'][class*='rounded-full']",
-    );
-    expect(dots.length).toBeGreaterThanOrEqual(2);
+    const berryPill = screen.getByRole("button", { name: "ベリー を編集" });
+    const citrusPill = screen.getByRole("button", { name: "シトラス を編集" });
+    expect(
+      berryPill.querySelector("[aria-hidden='true'][class*='rounded-full']"),
+    ).not.toBeNull();
+    expect(
+      citrusPill.querySelector("[aria-hidden='true'][class*='rounded-full']"),
+    ).not.toBeNull();
   });
 });

--- a/src/components/FlavorTagSettings.test.tsx
+++ b/src/components/FlavorTagSettings.test.tsx
@@ -63,8 +63,7 @@ describe("FlavorTagSettings", () => {
       expect(screen.getByText("フローラル")).toBeInTheDocument(),
     );
 
-    const item = screen.getByRole("listitem");
-    await user.click(within(item).getByRole("button", { name: "編集" }));
+    await user.click(screen.getByRole("button", { name: "フローラル を編集" }));
 
     const dialog = await screen.findByRole("dialog");
     const nameInput = within(dialog).getByLabelText("名前");
@@ -92,7 +91,7 @@ describe("FlavorTagSettings", () => {
     expect(await db.flavorTags.count()).toBe(0);
   });
 
-  it("「削除」ボタンで消える", async () => {
+  it("ピルをタップして編集フォームから削除できる", async () => {
     await db.flavorTags.add({
       id: "x",
       name: "ナッツ",
@@ -103,8 +102,9 @@ describe("FlavorTagSettings", () => {
     renderSection();
     await waitFor(() => expect(screen.getByText("ナッツ")).toBeInTheDocument());
 
-    const item = screen.getByRole("listitem");
-    await user.click(within(item).getByRole("button", { name: "削除" }));
+    await user.click(screen.getByRole("button", { name: "ナッツ を編集" }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "削除" }));
 
     await waitFor(() =>
       expect(screen.queryByText("ナッツ")).not.toBeInTheDocument(),

--- a/src/components/FlavorTagSettings.test.tsx
+++ b/src/components/FlavorTagSettings.test.tsx
@@ -14,12 +14,6 @@ function renderSection() {
   );
 }
 
-async function expand() {
-  await userEvent.click(
-    screen.getByRole("button", { name: "フレーバータグを展開" }),
-  );
-}
-
 describe("FlavorTagSettings", () => {
   beforeEach(async () => {
     await Promise.all([
@@ -31,38 +25,6 @@ describe("FlavorTagSettings", () => {
     ]);
   });
 
-  it("デフォルトで折りたたまれており、リストと追加ボタンが非表示", () => {
-    renderSection();
-    expect(
-      screen.queryByRole("button", { name: "フレーバータグを追加" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "フレーバータグを展開" }),
-    ).toHaveAttribute("aria-expanded", "false");
-  });
-
-  it("展開ボタンをクリックするとコンテンツが表示される", async () => {
-    renderSection();
-    await expand();
-    expect(
-      screen.getByRole("button", { name: "フレーバータグを追加" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "フレーバータグを折りたたむ" }),
-    ).toHaveAttribute("aria-expanded", "true");
-  });
-
-  it("展開後に再クリックすると折りたたまれる", async () => {
-    renderSection();
-    await expand();
-    await userEvent.click(
-      screen.getByRole("button", { name: "フレーバータグを折りたたむ" }),
-    );
-    expect(
-      screen.queryByRole("button", { name: "フレーバータグを追加" }),
-    ).not.toBeInTheDocument();
-  });
-
   it("登録済み FlavorTag を一覧表示する", async () => {
     await db.flavorTags.add({
       id: "a",
@@ -70,7 +32,6 @@ describe("FlavorTagSettings", () => {
       color: "#F9A8D4",
     });
     renderSection();
-    await expand();
     await waitFor(() =>
       expect(screen.getByText("フローラル")).toBeInTheDocument(),
     );
@@ -79,10 +40,9 @@ describe("FlavorTagSettings", () => {
   it("「追加」ボタンから新規作成できる", async () => {
     const user = userEvent.setup();
     renderSection();
-    await expand();
 
     await user.click(
-      screen.getByRole("button", { name: "フレーバータグを追加" }),
+      screen.getByRole("button", { name: "+ フレーバータグを追加" }),
     );
 
     const dialog = await screen.findByRole("dialog");
@@ -99,7 +59,6 @@ describe("FlavorTagSettings", () => {
 
     const user = userEvent.setup();
     renderSection();
-    await expand();
     await waitFor(() =>
       expect(screen.getByText("フローラル")).toBeInTheDocument(),
     );
@@ -122,10 +81,9 @@ describe("FlavorTagSettings", () => {
   it("名前が空の場合は保存されない", async () => {
     const user = userEvent.setup();
     renderSection();
-    await expand();
 
     await user.click(
-      screen.getByRole("button", { name: "フレーバータグを追加" }),
+      screen.getByRole("button", { name: "+ フレーバータグを追加" }),
     );
     const dialog = await screen.findByRole("dialog");
     await user.click(within(dialog).getByRole("button", { name: "保存" }));
@@ -143,7 +101,6 @@ describe("FlavorTagSettings", () => {
 
     const user = userEvent.setup();
     renderSection();
-    await expand();
     await waitFor(() => expect(screen.getByText("ナッツ")).toBeInTheDocument());
 
     const item = screen.getByRole("listitem");
@@ -152,5 +109,36 @@ describe("FlavorTagSettings", () => {
     await waitFor(() =>
       expect(screen.queryByText("ナッツ")).not.toBeInTheDocument(),
     );
+  });
+
+  it("タグは折りたたみなしで常時ピルとして表示される（展開ボタンがない）", async () => {
+    await db.flavorTags.add({
+      id: "p1",
+      name: "フローラル",
+      color: "#F9A8D4",
+    });
+    renderSection();
+    await waitFor(() =>
+      expect(screen.getByText("フローラル")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("button", { name: /展開|開く|折りたたみ/u }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("各ピルにタグ名と色ドットが表示される", async () => {
+    await Promise.all([
+      db.flavorTags.add({ id: "c1", name: "ベリー", color: "#C4B5FD" }),
+      db.flavorTags.add({ id: "c2", name: "シトラス", color: "#86EFAC" }),
+    ]);
+    renderSection();
+    await waitFor(() => expect(screen.getByText("ベリー")).toBeInTheDocument());
+    expect(screen.getByText("シトラス")).toBeInTheDocument();
+
+    // 各ピルに aria-hidden な色ドットが含まれる
+    const dots = document.querySelectorAll(
+      "[aria-hidden='true'][class*='rounded-full']",
+    );
+    expect(dots.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/src/components/FlavorTagSettings.tsx
+++ b/src/components/FlavorTagSettings.tsx
@@ -29,9 +29,8 @@ export function FlavorTagSettings() {
   const [collapsed, setCollapsed] = useState(true);
 
   return (
-    <section className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 p-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold">フレーバータグ</h2>
         <button
           type="button"
           onClick={() => setCollapsed((c) => !c)}
@@ -120,7 +119,7 @@ export function FlavorTagSettings() {
           </>
         )}
       </div>
-    </section>
+    </div>
   );
 }
 

--- a/src/components/FlavorTagSettings.tsx
+++ b/src/components/FlavorTagSettings.tsx
@@ -87,6 +87,7 @@ export function FlavorTagSettings() {
                 <button
                   type="button"
                   onClick={() => setDraft({ mode: "edit", tag })}
+                  aria-label={`${tag.name} を編集`}
                   className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-opacity hover:opacity-80"
                   style={{
                     backgroundColor: tag.color,
@@ -101,36 +102,19 @@ export function FlavorTagSettings() {
                   />
                   {tag.name}
                 </button>
-                {/* Screen-reader-only edit/delete buttons for full a11y */}
-                <button
-                  type="button"
-                  onClick={() => setDraft({ mode: "edit", tag })}
-                  className="sr-only"
-                >
-                  編集
-                </button>
-                <button
-                  type="button"
-                  onClick={() => del.mutate(tag.id)}
-                  className="sr-only"
-                >
-                  削除
-                </button>
               </li>
             );
           })}
         </ul>
       )}
 
-      <div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setDraft({ mode: "create" })}
-        >
-          + フレーバータグを追加
-        </Button>
-      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setDraft({ mode: "create" })}
+      >
+        + フレーバータグを追加
+      </Button>
     </div>
   );
 }

--- a/src/components/FlavorTagSettings.tsx
+++ b/src/components/FlavorTagSettings.tsx
@@ -1,5 +1,4 @@
 import { useForm } from "@tanstack/react-form";
-import { ChevronDown, ChevronUp } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -20,104 +19,117 @@ type Draft = { mode: "create" } | { mode: "edit"; tag: FlavorTag } | null;
 
 const empty: CreateFlavorTagInput = { name: "", color: "#F9A8D4" };
 
+/** Returns whether a hex color (#rrggbb) is perceptually light. */
+function isLightColor(hex: string): boolean {
+  const r = Number.parseInt(hex.slice(1, 3), 16);
+  const g = Number.parseInt(hex.slice(3, 5), 16);
+  const b = Number.parseInt(hex.slice(5, 7), 16);
+  // Relative luminance (simplified)
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.55;
+}
+
 export function FlavorTagSettings() {
   const { data: tags } = useFlavorTags();
   const create = useCreateFlavorTag();
   const update = useUpdateFlavorTag();
   const del = useDeleteFlavorTag();
   const [draft, setDraft] = useState<Draft>(null);
-  const [collapsed, setCollapsed] = useState(true);
 
   return (
     <div className="flex flex-col gap-3 p-4">
-      <div className="flex items-center justify-between">
-        <button
-          type="button"
-          onClick={() => setCollapsed((c) => !c)}
-          aria-expanded={!collapsed}
-          aria-controls="flavor-tag-content"
-          aria-label={
-            collapsed ? "フレーバータグを展開" : "フレーバータグを折りたたむ"
-          }
-          className="rounded p-1 hover:bg-muted"
+      {draft && (
+        <div
+          role="dialog"
+          aria-labelledby="flavor-tag-dialog-title"
+          className="rounded-lg border bg-muted/30 p-4"
         >
-          {collapsed ? (
-            <ChevronDown className="h-5 w-5" />
-          ) : (
-            <ChevronUp className="h-5 w-5" />
-          )}
-        </button>
-      </div>
-
-      <div id="flavor-tag-content">
-        {!collapsed && (
-          <>
-            <Button onClick={() => setDraft({ mode: "create" })}>
-              フレーバータグを追加
-            </Button>
-
-            {draft && (
-              <div
-                role="dialog"
-                aria-labelledby="flavor-tag-dialog-title"
-                className="rounded-lg border bg-muted/30 p-4"
-              >
-                <h3 id="flavor-tag-dialog-title" className="mb-3 font-medium">
-                  {draft.mode === "edit"
-                    ? "フレーバータグを編集"
-                    : "フレーバータグを追加"}
-                </h3>
-                <FlavorTagForm
-                  key={draft.mode === "edit" ? draft.tag.id : "new"}
-                  defaultValues={draft.mode === "edit" ? draft.tag : empty}
-                  onSubmit={async (input) => {
-                    if (draft.mode === "edit") {
-                      await update.mutateAsync({ ...draft.tag, ...input });
-                    } else {
-                      await create.mutateAsync(input);
-                    }
+          <h3 id="flavor-tag-dialog-title" className="mb-3 font-medium">
+            {draft.mode === "edit"
+              ? "フレーバータグを編集"
+              : "フレーバータグを追加"}
+          </h3>
+          <FlavorTagForm
+            key={draft.mode === "edit" ? draft.tag.id : "new"}
+            defaultValues={draft.mode === "edit" ? draft.tag : empty}
+            onSubmit={async (input) => {
+              if (draft.mode === "edit") {
+                await update.mutateAsync({ ...draft.tag, ...input });
+              } else {
+                await create.mutateAsync(input);
+              }
+              setDraft(null);
+            }}
+            onDelete={
+              draft.mode === "edit"
+                ? async () => {
+                    await del.mutateAsync(draft.tag.id);
                     setDraft(null);
-                  }}
-                  onCancel={() => setDraft(null)}
-                />
-              </div>
-            )}
+                  }
+                : undefined
+            }
+            onCancel={() => setDraft(null)}
+          />
+        </div>
+      )}
 
-            {tags?.length === 0 ? (
-              <p className="text-muted-foreground">
-                フレーバータグが登録されていません
-              </p>
-            ) : (
-              <ul className="flex flex-col gap-2">
-                {tags?.map((tag) => (
-                  <li
-                    key={tag.id}
-                    className="flex items-center gap-3 rounded-lg border p-3"
-                  >
-                    <span
-                      aria-hidden
-                      className="inline-block h-4 w-4 rounded-full"
-                      style={{ background: tag.color }}
-                    />
-                    <span className="flex-1">{tag.name}</span>
-                    <Button
-                      variant="outline"
-                      onClick={() => setDraft({ mode: "edit", tag })}
-                    >
-                      編集
-                    </Button>
-                    <Button
-                      variant="destructive"
-                      onClick={() => del.mutate(tag.id)}
-                    >
-                      削除
-                    </Button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </>
-        )}
+      {tags?.length === 0 ? (
+        <p className="text-muted-foreground">
+          フレーバータグが登録されていません
+        </p>
+      ) : (
+        <ul className="flex flex-wrap gap-2">
+          {tags?.map((tag) => {
+            const fg = isLightColor(tag.color) ? "#1a1a1a" : "#ffffff";
+            const borderColor = `${fg}55`;
+            return (
+              <li key={tag.id}>
+                <button
+                  type="button"
+                  onClick={() => setDraft({ mode: "edit", tag })}
+                  className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-opacity hover:opacity-80"
+                  style={{
+                    backgroundColor: tag.color,
+                    color: fg,
+                    borderColor,
+                  }}
+                >
+                  <span
+                    aria-hidden
+                    className="inline-block h-2 w-2 rounded-full flex-shrink-0"
+                    style={{ backgroundColor: fg }}
+                  />
+                  {tag.name}
+                </button>
+                {/* Screen-reader-only edit/delete buttons for full a11y */}
+                <button
+                  type="button"
+                  onClick={() => setDraft({ mode: "edit", tag })}
+                  className="sr-only"
+                >
+                  編集
+                </button>
+                <button
+                  type="button"
+                  onClick={() => del.mutate(tag.id)}
+                  className="sr-only"
+                >
+                  削除
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setDraft({ mode: "create" })}
+        >
+          + フレーバータグを追加
+        </Button>
       </div>
     </div>
   );
@@ -126,10 +138,12 @@ export function FlavorTagSettings() {
 function FlavorTagForm({
   defaultValues,
   onSubmit,
+  onDelete,
   onCancel,
 }: {
   defaultValues: CreateFlavorTagInput;
   onSubmit: (input: CreateFlavorTagInput) => void | Promise<void>;
+  onDelete?: () => void | Promise<void>;
   onCancel: () => void;
 }) {
   const form = useForm({
@@ -194,11 +208,18 @@ function FlavorTagForm({
           </div>
         )}
       </form.Field>
-      <div className="flex justify-end gap-2">
-        <Button type="button" variant="outline" onClick={onCancel}>
-          キャンセル
-        </Button>
-        <Button type="submit">保存</Button>
+      <div className="flex justify-between gap-2">
+        {onDelete && (
+          <Button type="button" variant="destructive" onClick={onDelete}>
+            削除
+          </Button>
+        )}
+        <div className="flex gap-2 ml-auto">
+          <Button type="button" variant="outline" onClick={onCancel}>
+            キャンセル
+          </Button>
+          <Button type="submit">保存</Button>
+        </div>
       </div>
     </form>
   );

--- a/src/components/LocationSettings.test.tsx
+++ b/src/components/LocationSettings.test.tsx
@@ -1,0 +1,79 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react/pure";
+import { beforeEach, describe, expect, it } from "vitest";
+import { LocationSettings } from "@/components/LocationSettings";
+
+const STORAGE_KEY = "roastlog.appSettings";
+
+function renderComponent() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <LocationSettings />
+    </QueryClientProvider>,
+  );
+}
+
+describe("LocationSettings", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("位置情報が設定済みのとき", () => {
+    beforeEach(() => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          locationLat: 36.0652,
+          locationLon: 136.2217,
+          locationLabel: "自宅（福井）",
+        }),
+      );
+    });
+
+    it("座標が mono フォントで表示される", async () => {
+      renderComponent();
+      await waitFor(() => {
+        const coord = screen.getByText(/36\.0652.*136\.2217/);
+        expect(coord).toBeInTheDocument();
+        expect(coord.className).toMatch(/font-mono/);
+      });
+    });
+
+    it("「再取得」ボタンが表示される", async () => {
+      renderComponent();
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "再取得" }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("場所ラベルが表示される", async () => {
+      renderComponent();
+      await waitFor(() => {
+        expect(screen.getByText("自宅（福井）")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("位置情報が未設定のとき", () => {
+    it("「位置情報が設定されていません」が表示される", async () => {
+      renderComponent();
+      await waitFor(() => {
+        expect(
+          screen.getByText("位置情報が設定されていません"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("「位置情報を取得する」ボタンが表示される", async () => {
+      renderComponent();
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "位置情報を取得する" }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/components/LocationSettings.test.tsx
+++ b/src/components/LocationSettings.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react/pure";
 import { beforeEach, describe, expect, it } from "vitest";
 import { LocationSettings } from "@/components/LocationSettings";
+import { db } from "@/db";
 
 const STORAGE_KEY = "roastlog.appSettings";
 
@@ -15,8 +16,15 @@ function renderComponent() {
 }
 
 describe("LocationSettings", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     localStorage.clear();
+    await Promise.all([
+      db.roastLevels.clear(),
+      db.flavorTags.clear(),
+      db.roastDevices.clear(),
+      db.beans.clear(),
+      db.roastLogs.clear(),
+    ]);
   });
 
   describe("位置情報が設定済みのとき", () => {

--- a/src/components/LocationSettings.tsx
+++ b/src/components/LocationSettings.tsx
@@ -64,9 +64,8 @@ export function LocationSettings() {
     settings.locationLat !== null && settings.locationLon !== null;
 
   return (
-    <section className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 p-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold">位置情報</h2>
         <Button onClick={handleFetchLocation} disabled={busy}>
           {busy ? "取得中..." : "位置情報を取得する"}
         </Button>
@@ -112,7 +111,7 @@ export function LocationSettings() {
           await update.mutateAsync({ ...settings, locationLabel: label });
         }}
       />
-    </section>
+    </div>
   );
 }
 

--- a/src/components/LocationSettings.tsx
+++ b/src/components/LocationSettings.tsx
@@ -1,29 +1,11 @@
 import { useForm } from "@tanstack/react-form";
+import { MapPin } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAppSettings, useUpdateAppSettings } from "@/hooks/useAppSettings";
 import { AppSettingsSchema } from "@/schemas/appSettings";
-
-function PinIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="size-5"
-      aria-hidden="true"
-    >
-      <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
-      <circle cx="12" cy="10" r="3" />
-    </svg>
-  );
-}
 
 export function LocationSettings() {
   const { data: settings, isLoading } = useAppSettings();
@@ -87,7 +69,7 @@ export function LocationSettings() {
       {hasLocation ? (
         <div className="flex items-center gap-3">
           <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-            <PinIcon />
+            <MapPin className="size-5" aria-hidden />
           </div>
           <div className="flex min-w-0 flex-1 flex-col">
             <span className="text-sm font-medium">
@@ -127,7 +109,7 @@ export function LocationSettings() {
       {hasLocation && (
         <>
           <LocationLabelForm
-            key={settings.locationLabel}
+            key={settings.locationLabel || "__no_label__"}
             currentLabel={settings.locationLabel}
             onSubmit={async (label) => {
               await update.mutateAsync({ ...settings, locationLabel: label });

--- a/src/components/LocationSettings.tsx
+++ b/src/components/LocationSettings.tsx
@@ -6,6 +6,25 @@ import { Label } from "@/components/ui/label";
 import { useAppSettings, useUpdateAppSettings } from "@/hooks/useAppSettings";
 import { AppSettingsSchema } from "@/schemas/appSettings";
 
+function PinIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-5"
+      aria-hidden="true"
+    >
+      <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  );
+}
+
 export function LocationSettings() {
   const { data: settings, isLoading } = useAppSettings();
   const update = useUpdateAppSettings();
@@ -65,52 +84,65 @@ export function LocationSettings() {
 
   return (
     <div className="flex flex-col gap-3 p-4">
-      <div className="flex items-center justify-between">
-        <Button onClick={handleFetchLocation} disabled={busy}>
-          {busy ? "取得中..." : "位置情報を取得する"}
-        </Button>
-      </div>
-
-      <p className="text-sm text-muted-foreground">
-        焙煎ログ作成時に外気温・湿度・天気を自動取得します。位置情報は端末内（localStorage）にのみ保存されます。
-      </p>
-
-      <div className="rounded-lg border p-3 flex flex-col gap-2">
-        {hasLocation ? (
-          <>
-            <div className="flex items-center justify-between gap-2">
-              <span className="text-sm">
-                {settings.locationLabel || "（場所名なし）"}
-              </span>
-              <Button variant="outline" onClick={handleClearLocation}>
-                位置情報を削除
-              </Button>
-            </div>
-            <div className="text-xs font-mono text-muted-foreground">
-              緯度 {settings.locationLat?.toFixed(4)}, 経度{" "}
+      {hasLocation ? (
+        <div className="flex items-center gap-3">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <PinIcon />
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="text-sm font-medium">
+              {settings.locationLabel || "（場所名なし）"}
+            </span>
+            <span className="font-mono text-xs text-muted-foreground">
+              {settings.locationLat?.toFixed(4)},{" "}
               {settings.locationLon?.toFixed(4)}
-            </div>
-          </>
-        ) : (
+            </span>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleFetchLocation}
+            disabled={busy}
+          >
+            {busy ? "取得中..." : "再取得"}
+          </Button>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between gap-2">
           <p className="text-sm text-muted-foreground">
             位置情報が設定されていません
           </p>
-        )}
+          <Button onClick={handleFetchLocation} disabled={busy} size="sm">
+            {busy ? "取得中..." : "位置情報を取得する"}
+          </Button>
+        </div>
+      )}
 
-        {error && (
-          <p role="alert" className="text-sm text-destructive">
-            {error}
-          </p>
-        )}
-      </div>
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
 
-      <LocationLabelForm
-        key={settings.locationLabel}
-        currentLabel={settings.locationLabel}
-        onSubmit={async (label) => {
-          await update.mutateAsync({ ...settings, locationLabel: label });
-        }}
-      />
+      {hasLocation && (
+        <>
+          <LocationLabelForm
+            key={settings.locationLabel}
+            currentLabel={settings.locationLabel}
+            onSubmit={async (label) => {
+              await update.mutateAsync({ ...settings, locationLabel: label });
+            }}
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="self-start text-muted-foreground"
+            onClick={handleClearLocation}
+          >
+            位置情報を削除
+          </Button>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/RoastDeviceSettings.test.tsx
+++ b/src/components/RoastDeviceSettings.test.tsx
@@ -96,6 +96,27 @@ describe("RoastDeviceSettings", () => {
     expect(await db.roastDevices.count()).toBe(0);
   });
 
+  it("「焙煎機を追加」ボタンがデバイスリストの後に表示される", async () => {
+    await db.roastDevices.add({
+      id: "order-test",
+      name: "Test Roaster",
+      method: "熱風式",
+      note: "",
+    });
+    renderSection();
+    await waitFor(() =>
+      expect(screen.getByText("Test Roaster")).toBeInTheDocument(),
+    );
+
+    const addButton = screen.getByRole("button", { name: "焙煎機を追加" });
+    const listItem = screen.getByRole("listitem");
+    // addButton は listitem より後（DOM順）に来るべき
+    expect(
+      addButton.compareDocumentPosition(listItem) &
+        Node.DOCUMENT_POSITION_PRECEDING,
+    ).toBeTruthy();
+  });
+
   it("「削除」ボタンで消える", async () => {
     await db.roastDevices.add({
       id: "x",

--- a/src/components/RoastDeviceSettings.tsx
+++ b/src/components/RoastDeviceSettings.tsx
@@ -27,9 +27,8 @@ export function RoastDeviceSettings() {
   const [draft, setDraft] = useState<Draft>(null);
 
   return (
-    <section className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 p-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold">焙煎機</h2>
         <Button onClick={() => setDraft({ mode: "create" })}>
           焙煎機を追加
         </Button>
@@ -96,7 +95,7 @@ export function RoastDeviceSettings() {
           ))}
         </ul>
       )}
-    </section>
+    </div>
   );
 }
 

--- a/src/components/RoastDeviceSettings.tsx
+++ b/src/components/RoastDeviceSettings.tsx
@@ -19,6 +19,26 @@ type Draft = { mode: "create" } | { mode: "edit"; device: RoastDevice } | null;
 
 const empty: CreateRoastDeviceInput = { name: "", method: "", note: "" };
 
+function RoastDeviceIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 8h18v10a2 2 0 01-2 2H5a2 2 0 01-2-2V8z" />
+      <path d="M7 8V5a2 2 0 012-2h6a2 2 0 012 2v3" />
+      <path d="M12 11v5M9 13l3-2 3 2" />
+    </svg>
+  );
+}
+
 export function RoastDeviceSettings() {
   const { data: devices } = useRoastDevices();
   const create = useCreateRoastDevice();
@@ -28,12 +48,6 @@ export function RoastDeviceSettings() {
 
   return (
     <div className="flex flex-col gap-3 p-4">
-      <div className="flex items-center justify-between">
-        <Button onClick={() => setDraft({ mode: "create" })}>
-          焙煎機を追加
-        </Button>
-      </div>
-
       {draft && (
         <div
           role="dialog"
@@ -66,35 +80,48 @@ export function RoastDeviceSettings() {
           {devices?.map((device) => (
             <li
               key={device.id}
-              className="flex flex-col gap-1 rounded-lg border p-3"
+              className="flex items-center gap-3 rounded-lg border p-3"
             >
-              <div className="flex items-center gap-2">
-                <span className="flex-1 font-medium">{device.name}</span>
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-secondary-foreground">
+                <RoastDeviceIcon />
+              </div>
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="text-sm font-medium">{device.name}</span>
                 {device.method && (
-                  <span className="text-sm text-muted-foreground">
+                  <span className="text-xs text-muted-foreground">
                     {device.method}
                   </span>
                 )}
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
                 <Button
-                  variant="outline"
+                  variant="ghost"
+                  size="sm"
+                  className="text-primary"
                   onClick={() => setDraft({ mode: "edit", device })}
                 >
                   編集
                 </Button>
                 <Button
                   variant="destructive"
+                  size="sm"
                   onClick={() => del.mutate(device.id)}
                 >
                   削除
                 </Button>
               </div>
-              {device.note && (
-                <p className="text-sm text-muted-foreground">{device.note}</p>
-              )}
             </li>
           ))}
         </ul>
       )}
+
+      <Button
+        variant="outline"
+        className="w-full"
+        onClick={() => setDraft({ mode: "create" })}
+      >
+        焙煎機を追加
+      </Button>
     </div>
   );
 }

--- a/src/components/RoastLevelSettings.test.tsx
+++ b/src/components/RoastLevelSettings.test.tsx
@@ -156,4 +156,46 @@ describe("RoastLevelSettings", () => {
       expect(screen.queryByText("中煎り")).not.toBeInTheDocument(),
     );
   });
+
+  describe("折りたたみプレビュー", () => {
+    it("折りたたみ状態でカラードットが表示される", async () => {
+      await db.roastLevels.bulkAdd([
+        { id: "a", label: "浅煎り", color: "#E8C84A", order: 1 },
+        { id: "b", label: "深煎り", color: "#3E1A06", order: 5 },
+      ]);
+
+      renderSection();
+
+      // デフォルトは折りたたみ状態 — カラードットが表示されるはず
+      const dots = await screen.findAllByTestId("color-dot");
+      expect(dots).toHaveLength(2);
+      // inline style の background は background-color として展開される
+      expect(dots[0]).toHaveStyle("background-color: #E8C84A");
+      expect(dots[1]).toHaveStyle("background-color: #3E1A06");
+    });
+
+    it("折りたたみ状態で件数ラベルが表示される", async () => {
+      await db.roastLevels.bulkAdd([
+        { id: "a", label: "浅煎り", color: "#E8C84A", order: 1 },
+        { id: "b", label: "中煎り", color: "#B06B1E", order: 3 },
+        { id: "c", label: "深煎り", color: "#3E1A06", order: 5 },
+      ]);
+
+      renderSection();
+
+      // デフォルトは折りたたみ状態 — 件数ラベルが表示されるはず
+      await waitFor(() => expect(screen.getByText("3 件")).toBeInTheDocument());
+    });
+
+    it("焙煎度がない場合は折りたたみ状態でドットと件数が表示されない", async () => {
+      renderSection();
+
+      // 0件の場合は件数ラベルなし
+      expect(
+        screen.getByRole("button", { name: "焙煎度を展開" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/\d+ 件/)).not.toBeInTheDocument();
+      expect(screen.queryByTestId("color-dot")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/RoastLevelSettings.tsx
+++ b/src/components/RoastLevelSettings.tsx
@@ -37,13 +37,33 @@ export function RoastLevelSettings() {
           aria-expanded={!collapsed}
           aria-controls="roast-level-content"
           aria-label={collapsed ? "焙煎度を展開" : "焙煎度を折りたたむ"}
-          className="rounded p-1 hover:bg-muted"
+          className="flex flex-1 items-center gap-2 rounded p-1 hover:bg-muted"
         >
-          {collapsed ? (
-            <ChevronDown className="h-5 w-5" />
-          ) : (
-            <ChevronUp className="h-5 w-5" />
+          {collapsed && levels && levels.length > 0 && (
+            <>
+              <span className="flex items-center gap-1">
+                {levels.map((level) => (
+                  <span
+                    key={level.id}
+                    data-testid="color-dot"
+                    aria-hidden
+                    className="inline-block h-2 w-2 rounded-full"
+                    style={{ background: level.color }}
+                  />
+                ))}
+              </span>
+              <span className="text-sm text-muted-foreground">
+                {levels.length} 件
+              </span>
+            </>
           )}
+          <span className="ml-auto">
+            {collapsed ? (
+              <ChevronDown className="h-5 w-5" />
+            ) : (
+              <ChevronUp className="h-5 w-5" />
+            )}
+          </span>
         </button>
       </div>
 

--- a/src/components/RoastLevelSettings.tsx
+++ b/src/components/RoastLevelSettings.tsx
@@ -29,9 +29,8 @@ export function RoastLevelSettings() {
   const [collapsed, setCollapsed] = useState(true);
 
   return (
-    <section className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 p-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold">焙煎度</h2>
         <button
           type="button"
           onClick={() => setCollapsed((c) => !c)}
@@ -119,7 +118,7 @@ export function RoastLevelSettings() {
           </>
         )}
       </div>
-    </section>
+    </div>
   );
 }
 

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -51,11 +51,53 @@ describe("SettingsPage", () => {
     ]);
   });
 
+  it("「位置情報」セクションが「焙煎度ラベル」セクションより前に表示される", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "位置情報" }),
+      ).toBeInTheDocument();
+    });
+    const headings = screen.getAllByRole("heading", { level: 2 });
+    const labels = headings.map((h) => h.textContent);
+    expect(labels.indexOf("位置情報")).toBeLessThan(
+      labels.indexOf("焙煎度ラベル"),
+    );
+  });
+
+  it("5つのセクション見出しが正しい順序で表示される", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "位置情報", level: 2 }),
+      ).toBeInTheDocument();
+    });
+    const headings = screen.getAllByRole("heading", { level: 2 });
+    const labels = headings.map((h) => h.textContent);
+    const order = [
+      "位置情報",
+      "焙煎度ラベル",
+      "フレーバータグ",
+      "焙煎機",
+      "データ管理",
+    ];
+    const indices = order.map((label) => labels.indexOf(label));
+    for (const [i, idx] of indices.entries()) {
+      expect(idx, `${order[i]} が見つからない`).toBeGreaterThanOrEqual(0);
+    }
+    for (let i = 0; i < indices.length - 1; i++) {
+      expect(
+        indices[i],
+        `${order[i]} は ${order[i + 1]} より前に表示される必要がある`,
+      ).toBeLessThan(indices[i + 1]);
+    }
+  });
+
   it("3 つのマスター管理セクションを表示する", async () => {
     renderPage();
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: "焙煎度", level: 2 }),
+        screen.getByRole("heading", { name: "焙煎度ラベル", level: 2 }),
       ).toBeInTheDocument();
     });
     expect(

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -5,20 +5,49 @@ import { LocationSettings } from "@/components/LocationSettings";
 import { RoastDeviceSettings } from "@/components/RoastDeviceSettings";
 import { RoastLevelSettings } from "@/components/RoastLevelSettings";
 
+function SettingsSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <h2 className="px-1 text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground">
+        {label}
+      </h2>
+      <div className="overflow-hidden rounded-md border border-border bg-card shadow-sm">
+        {children}
+      </div>
+    </div>
+  );
+}
+
 export function SettingsPage() {
   return (
-    <div className="flex flex-col gap-8 p-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">設定</h1>
+    <div className="flex flex-col gap-6 p-4">
+      <div className="flex items-center justify-between py-2">
+        <h1 className="text-xl font-semibold">設定</h1>
         <Link to="/beans" className="text-sm underline">
           ← 生豆一覧へ
         </Link>
       </div>
-      <RoastLevelSettings />
-      <FlavorTagSettings />
-      <RoastDeviceSettings />
-      <LocationSettings />
-      <CsvSection />
+      <SettingsSection label="位置情報">
+        <LocationSettings />
+      </SettingsSection>
+      <SettingsSection label="焙煎度ラベル">
+        <RoastLevelSettings />
+      </SettingsSection>
+      <SettingsSection label="フレーバータグ">
+        <FlavorTagSettings />
+      </SettingsSection>
+      <SettingsSection label="焙煎機">
+        <RoastDeviceSettings />
+      </SettingsSection>
+      <SettingsSection label="データ管理">
+        <CsvSection />
+      </SettingsSection>
     </div>
   );
 }

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,4 +1,3 @@
-import { Link } from "@tanstack/react-router";
 import { CsvSection } from "@/components/CsvSection";
 import { FlavorTagSettings } from "@/components/FlavorTagSettings";
 import { LocationSettings } from "@/components/LocationSettings";
@@ -27,12 +26,7 @@ function SettingsSection({
 export function SettingsPage() {
   return (
     <div className="flex flex-col gap-6 p-4">
-      <div className="flex items-center justify-between py-2">
-        <h1 className="text-xl font-semibold">設定</h1>
-        <Link to="/beans" className="text-sm underline">
-          ← 生豆一覧へ
-        </Link>
-      </div>
+      <h1 className="py-2 text-xl font-semibold">設定</h1>
       <SettingsSection label="位置情報">
         <LocationSettings />
       </SettingsSection>


### PR DESCRIPTION
## Summary

- **#49** `SettingsSection` 導入によるセクション順・見出しスタイル・カードコンテナの統一
- **#50** 焙煎度ラベルの折りたたみプレビュー行強化（カラードット列 + 件数 + シェブロン）
- **#51** フレーバータグをピル表示化（折りたたみ廃止、カラーピル常時表示）
- **#52** 位置情報セクションをアイコン付きカードレイアウト化 + テスト新規追加
- **#53** 焙煎機セクションをアイコン付きカード + 追加ボタンを下配置に変更
- **simplify** sr-only 冗長ボタン除去・`PinIcon` を lucide `MapPin` に置換・不要リンク削除

## Test plan

- [ ] 全ブラウザテスト（`npm run test:browser`）グリーン確認
- [ ] 設定画面：5セクションが「位置情報→焙煎度ラベル→フレーバータグ→焙煎機→データ管理」の順に表示
- [ ] 焙煎度ラベル：折りたたみ時にカラードット列と件数が見える
- [ ] フレーバータグ：折りたたみなしでカラーピルが常時表示。ピルタップで編集ダイアログが開く
- [ ] 位置情報：設定済み時にピンアイコン・場所名・座標・「再取得」ボタンのカードが表示
- [ ] 焙煎機：アイコン付きカード、「焙煎機を追加」ボタンがリスト下に表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI改善**
  * CsvSection の外側要素を section→div に変更し見出しブロックを削除
  * フレーバータグを常時表示化、一覧から削除ボタンを除外して編集フォームへ移動（色コントラスト調整）
  * 位置情報表示をコンテナ内に再構成・座標表記を font-mono の lat, lon に変更
  * 焙煎機をカード型リストへ変更・アイコン追加
  * 設定ページをセクション単位でカード化・表示順調整

* **テスト**
  * 各設定セクションの表示／操作に関するテストを追加・更新（表示順・折りたたみ挙動・ローカルストレージ連動など）

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otufor/RoastLog/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->