### PR TITLE
feat(theme): ダークモード手動切替 & ハードコード色の修正

### DIFF
--- a/src/components/AnalysisPage.tsx
+++ b/src/components/AnalysisPage.tsx
@@ -26,16 +26,11 @@ const RADAR_KEYS_JP: Record<string, string> = {
   cleanliness: "クリーン",
 };
 
-const COLOR_1 = "#2D7D52";
-const COLOR_2 = "#B06B1E";
+const COLOR_1 = "#10B981";
+const COLOR_2 = "#F97316";
 
-const tooltipStyle = {
-  background: "var(--card)",
-  border: "1px solid var(--border)",
-  borderRadius: 6,
-  padding: "6px 10px",
-  fontSize: 13,
-} as const;
+const TOOLTIP_CLASS =
+  "bg-card text-card-foreground border border-border rounded-sm px-2.5 py-1.5 text-[13px]";
 
 const emptyMessageStyle = {
   fontSize: 13,
@@ -124,6 +119,7 @@ export function AnalysisPage() {
   ];
   const radarData =
     radarEntries.length > 0 ? buildRadarChartData(radarEntries) : null;
+  const radarKeys = radarEntries.map((e) => e.label);
 
   return (
     <div className="p-4 flex flex-col gap-8">
@@ -170,6 +166,7 @@ export function AnalysisPage() {
                 xScale={{ type: "linear" }}
                 yScale={{ type: "linear", stacked: false }}
                 yFormat=">-.1f"
+                theme={{ text: { fill: "currentColor" } }}
                 axisBottom={{
                   legend: "焙煎回数",
                   legendOffset: 32,
@@ -178,7 +175,7 @@ export function AnalysisPage() {
                 axisLeft={{ legend: "減少率 (%)", legendOffset: -40 }}
                 useMesh
                 tooltip={({ point }) => (
-                  <div data-testid="analysis-tooltip" style={tooltipStyle}>
+                  <div data-testid="analysis-tooltip" className={TOOLTIP_CLASS}>
                     {point.data.yFormatted}%
                   </div>
                 )}
@@ -264,12 +261,12 @@ export function AnalysisPage() {
           <div data-testid="radar-chart" style={{ height: 350 }}>
             <ResponsiveRadar
               data={radarData}
-              keys={["ログ1", "ログ2"]}
+              keys={radarKeys}
               indexBy="metric"
               valueFormat=">-.1f"
               maxValue={5}
               colors={[COLOR_1, COLOR_2]}
-              fillOpacity={0.3}
+              fillOpacity={0.4}
               margin={{ top: 40, right: 60, bottom: 40, left: 60 }}
               gridLabelOffset={16}
               gridLabel={({ id, anchor, x, y }) => (
@@ -278,10 +275,31 @@ export function AnalysisPage() {
                     textAnchor={anchor}
                     dominantBaseline="central"
                     fontSize={12}
+                    fill="currentColor"
                   >
                     {RADAR_KEYS_JP[id] ?? id}
                   </text>
                 </g>
+              )}
+              sliceTooltip={({ index, data }) => (
+                <div className={TOOLTIP_CLASS}>
+                  <div className="font-semibold mb-1">
+                    {RADAR_KEYS_JP[String(index)] ?? String(index)}
+                  </div>
+                  {data.map((d) => (
+                    <div
+                      key={String(d.id)}
+                      className="flex items-center gap-1.5"
+                    >
+                      <span
+                        className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                        style={{ background: d.color }}
+                      />
+                      <span>{String(d.id)}</span>
+                      <span className="ml-auto pl-3">{d.formattedValue}</span>
+                    </div>
+                  ))}
+                </div>
               )}
             />
           </div>

--- a/src/components/BeanDetailPage.tsx
+++ b/src/components/BeanDetailPage.tsx
@@ -282,7 +282,7 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
             border: "0.5px solid var(--border)",
             borderRadius: 10,
             padding: "14px 16px",
-            boxShadow: "0 1px 2px rgba(28,23,20,0.04)",
+            boxShadow: "0 1px 2px rgba(0,0,0,0.06)",
             marginBottom: 12,
           }}
         >
@@ -366,7 +366,7 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
             border: "0.5px solid var(--border)",
             borderRadius: 10,
             overflow: "hidden",
-            boxShadow: "0 1px 2px rgba(28,23,20,0.04)",
+            boxShadow: "0 1px 2px rgba(0,0,0,0.06)",
             marginBottom: 12,
           }}
         >
@@ -429,7 +429,7 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
                 border: "0.5px solid #2D7D52",
                 borderRadius: 10,
                 padding: "12px 14px",
-                boxShadow: "0 1px 2px rgba(28,23,20,0.04)",
+                boxShadow: "0 1px 2px rgba(0,0,0,0.06)",
                 display: "flex",
                 justifyContent: "space-between",
                 alignItems: "center",
@@ -457,7 +457,7 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
                       fontWeight: 500,
                       padding: "2px 7px",
                       borderRadius: 999,
-                      background: "#E0F2E9",
+                      background: "rgba(45,125,82,0.12)",
                       color: "#2D7D52",
                     }}
                   >
@@ -506,7 +506,7 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
                 border: "0.5px solid var(--border)",
                 borderRadius: 10,
                 padding: "12px 14px",
-                boxShadow: "0 1px 2px rgba(28,23,20,0.04)",
+                boxShadow: "0 1px 2px rgba(0,0,0,0.06)",
                 display: "flex",
                 justifyContent: "space-between",
                 alignItems: "center",
@@ -613,7 +613,7 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
                       border: `0.5px solid ${isBest ? "#2D7D52" : "var(--border)"}`,
                       borderRadius: 10,
                       padding: "10px 14px",
-                      boxShadow: "0 1px 2px rgba(28,23,20,0.04)",
+                      boxShadow: "0 1px 2px rgba(0,0,0,0.06)",
                       display: "flex",
                       justifyContent: "space-between",
                       alignItems: "center",
@@ -637,7 +637,7 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
                               fontWeight: 500,
                               padding: "2px 7px",
                               borderRadius: 999,
-                              background: "#E0F2E9",
+                              background: "rgba(45,125,82,0.12)",
                               color: "#2D7D52",
                             }}
                           >
@@ -729,7 +729,7 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
             style={{
               position: "absolute",
               inset: 0,
-              background: "rgba(28,23,20,0.4)",
+              background: "rgba(0,0,0,0.5)",
               border: 0,
               cursor: "default",
             }}
@@ -744,7 +744,7 @@ export function BeanDetailPage({ beanId }: { beanId: string }) {
               background: "var(--card)",
               borderTopLeftRadius: 16,
               borderTopRightRadius: 16,
-              boxShadow: "0 -4px 20px rgba(28,23,20,0.12)",
+              boxShadow: "0 -4px 20px rgba(0,0,0,0.15)",
               padding: "14px 16px 32px",
             }}
           >

--- a/src/components/BeanForm.tsx
+++ b/src/components/BeanForm.tsx
@@ -160,7 +160,7 @@ export function BeanForm({
                 height: 44,
                 padding: "0 12px",
                 background: "var(--muted)",
-                border: `0.5px solid ${field.state.meta.errors.length > 0 ? "#B83232" : "var(--border)"}`,
+                border: `0.5px solid ${field.state.meta.errors.length > 0 ? "var(--destructive)" : "var(--border)"}`,
                 borderRadius: 8,
                 fontSize: 14,
                 color: "var(--foreground)",
@@ -175,7 +175,7 @@ export function BeanForm({
                   role="alert"
                   style={{
                     fontSize: 12,
-                    color: "#B83232",
+                    color: "var(--destructive)",
                     marginTop: 4,
                     display: "block",
                   }}

--- a/src/components/BeanListPage.tsx
+++ b/src/components/BeanListPage.tsx
@@ -62,9 +62,9 @@ function StockBadge({ pct }: { pct: number }) {
           fontWeight: 500,
           padding: "2px 7px",
           borderRadius: 999,
-          background: "#FDEAEA",
+          background: "rgba(184,50,50,0.12)",
           color: "#B83232",
-          border: "0.5px solid #B8323233",
+          border: "0.5px solid rgba(184,50,50,0.25)",
         }}
       >
         残りわずか
@@ -128,13 +128,13 @@ export function BeanListPage() {
   ): React.CSSProperties {
     const active = filterStock === id;
     let bg = active ? "var(--foreground)" : "var(--card)";
-    let color = active ? "#fff" : "var(--muted-foreground)";
+    let color = active ? "var(--background)" : "var(--muted-foreground)";
     if (!active && warn && lowStockCount > 0) {
-      bg = "#FFF8E8";
+      bg = "rgba(212,148,58,0.12)";
       color = "#D4943A";
     }
     if (!active && danger && outStockCount > 0) {
-      bg = "#FDEAEA";
+      bg = "rgba(184,50,50,0.12)";
       color = "#B83232";
     }
     return {
@@ -386,7 +386,7 @@ export function BeanListPage() {
                   borderRadius: 10,
                   padding: 12,
                   boxShadow:
-                    "0 1px 2px rgba(28,23,20,0.04), 0 1px 1px rgba(28,23,20,0.03)",
+                    "0 1px 2px rgba(0,0,0,0.06), 0 1px 1px rgba(0,0,0,0.04)",
                   cursor: "pointer",
                   textAlign: "left",
                   width: "100%",
@@ -555,7 +555,7 @@ export function BeanListPage() {
           alignItems: "center",
           justifyContent: "center",
           boxShadow:
-            "0 4px 12px rgba(176,107,30,0.28), 0 2px 4px rgba(28,23,20,0.08)",
+            "0 4px 12px rgba(176,107,30,0.28), 0 2px 4px rgba(0,0,0,0.10)",
         }}
       >
         ＋

--- a/src/components/RoastLogListPage.tsx
+++ b/src/components/RoastLogListPage.tsx
@@ -167,7 +167,7 @@ export function RoastLogListPage() {
                 fontSize: 12,
                 fontWeight: 500,
                 background: active ? "var(--foreground)" : "var(--card)",
-                color: active ? "#FFFFFF" : "var(--muted-foreground)",
+                color: active ? "var(--background)" : "var(--muted-foreground)",
                 border: active
                   ? "0.5px solid var(--foreground)"
                   : "0.5px solid var(--border)",
@@ -408,7 +408,7 @@ export function RoastLogListPage() {
                   borderRadius: 10,
                   padding: 12,
                   boxShadow:
-                    "0 1px 2px rgba(28,23,20,0.04), 0 1px 1px rgba(28,23,20,0.03)",
+                    "0 1px 2px rgba(0,0,0,0.06), 0 1px 1px rgba(0,0,0,0.04)",
                   cursor: "pointer",
                   textAlign: "left",
                   width: "100%",
@@ -440,7 +440,7 @@ export function RoastLogListPage() {
                         fontWeight: 500,
                         padding: "3px 8px",
                         borderRadius: 999,
-                        background: "#FDEAEA",
+                        background: "rgba(184,50,50,0.12)",
                         color: "#B83232",
                         flexShrink: 0,
                       }}
@@ -489,7 +489,7 @@ export function RoastLogListPage() {
                         fontWeight: 500,
                         padding: "3px 8px",
                         borderRadius: 999,
-                        background: "#E0F2E9",
+                        background: "rgba(45,125,82,0.12)",
                         color: "#2D7D52",
                       }}
                     >
@@ -535,7 +535,7 @@ export function RoastLogListPage() {
             justifyContent: "center",
             gap: 8,
             boxShadow:
-              "0 4px 12px rgba(176,107,30,0.28), 0 2px 4px rgba(28,23,20,0.08)",
+              "0 4px 12px rgba(176,107,30,0.28), 0 2px 4px rgba(0,0,0,0.10)",
           }}
         >
           <svg

--- a/src/components/RootLayout.test.tsx
+++ b/src/components/RootLayout.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   createMemoryHistory,
   createRoute,
@@ -18,7 +19,12 @@ function renderRoot() {
     routeTree: RootRoute.addChildren([indexRoute]),
     history: createMemoryHistory({ initialEntries: ["/"] }),
   });
-  return render(<RouterProvider router={router} />);
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
 }
 
 describe("RootLayout", () => {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { FlavorTagSettings } from "@/components/FlavorTagSettings";
 import { LocationSettings } from "@/components/LocationSettings";
 import { RoastDeviceSettings } from "@/components/RoastDeviceSettings";
 import { RoastLevelSettings } from "@/components/RoastLevelSettings";
+import { ThemeSettings } from "@/components/ThemeSettings";
 
 function SettingsSection({
   label,
@@ -27,6 +28,9 @@ export function SettingsPage() {
   return (
     <div className="flex flex-col gap-6 p-4">
       <h1 className="py-2 text-xl font-semibold">設定</h1>
+      <SettingsSection label="外観">
+        <ThemeSettings />
+      </SettingsSection>
       <SettingsSection label="位置情報">
         <LocationSettings />
       </SettingsSection>

--- a/src/components/StarRating.tsx
+++ b/src/components/StarRating.tsx
@@ -30,7 +30,7 @@ export function StarRating({ value, max = 5, size = 16, onChange }: Props) {
                 border: 0,
                 padding: 0,
                 cursor: "pointer",
-                color: filled ? "#D4943A" : "var(--border)",
+                color: filled ? "#D4943A" : "var(--muted-foreground)",
                 fontSize: size,
                 lineHeight: 1,
                 minWidth: 44,
@@ -50,7 +50,7 @@ export function StarRating({ value, max = 5, size = 16, onChange }: Props) {
             key={i}
             aria-hidden="true"
             style={{
-              color: filled ? "#D4943A" : "var(--border)",
+              color: filled ? "#D4943A" : "var(--muted-foreground)",
               fontSize: size,
               lineHeight: 1,
             }}

--- a/src/components/ThemeSettings.tsx
+++ b/src/components/ThemeSettings.tsx
@@ -1,0 +1,58 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useAppSettings, useUpdateAppSettings } from "@/hooks/useAppSettings";
+import { cn } from "@/lib/utils";
+import type { Theme } from "@/schemas/appSettings";
+
+const OPTIONS: { value: Theme; label: string; icon: React.ReactNode }[] = [
+  {
+    value: "system",
+    label: "システム",
+    icon: <Monitor className="size-4" aria-hidden />,
+  },
+  {
+    value: "light",
+    label: "ライト",
+    icon: <Sun className="size-4" aria-hidden />,
+  },
+  {
+    value: "dark",
+    label: "ダーク",
+    icon: <Moon className="size-4" aria-hidden />,
+  },
+];
+
+export function ThemeSettings() {
+  const { data: settings, isLoading } = useAppSettings();
+  const update = useUpdateAppSettings();
+
+  if (isLoading || !settings) return null;
+
+  const current = settings.theme;
+
+  return (
+    <fieldset className="m-0 flex items-center justify-between gap-4 border-0 p-4">
+      <legend className="float-left text-sm">カラーモード</legend>
+      <div className="flex overflow-hidden rounded-md border border-border">
+        {OPTIONS.map(({ value, label, icon }) => (
+          <button
+            key={value}
+            type="button"
+            aria-pressed={current === value}
+            onClick={() => update.mutate({ ...settings, theme: value })}
+            className={cn(
+              "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+              "not-first:border-l not-first:border-border",
+              current === value
+                ? "bg-primary text-primary-foreground"
+                : "bg-background text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+          >
+            {icon}
+            {label}
+          </button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -29,32 +29,32 @@ describe("useTheme", () => {
     vi.restoreAllMocks();
   });
 
-  it("ダークモード設定時 .dark クラスが付く", () => {
+  it("system: ダークモード設定時 .dark クラスが付く", () => {
     const mq = makeMediaQuery(true);
     vi.spyOn(window, "matchMedia").mockReturnValue(
       mq as unknown as MediaQueryList,
     );
-    const { unmount } = renderHook(() => useTheme());
+    const { unmount } = renderHook(() => useTheme("system"));
     expect(document.documentElement.classList.contains("dark")).toBe(true);
     unmount();
   });
 
-  it("ライトモード設定時 .dark クラスが付かない", () => {
+  it("system: ライトモード設定時 .dark クラスが付かない", () => {
     const mq = makeMediaQuery(false);
     vi.spyOn(window, "matchMedia").mockReturnValue(
       mq as unknown as MediaQueryList,
     );
-    const { unmount } = renderHook(() => useTheme());
+    const { unmount } = renderHook(() => useTheme("system"));
     expect(document.documentElement.classList.contains("dark")).toBe(false);
     unmount();
   });
 
-  it("設定変更で .dark クラスがリロードなしに切り替わる", () => {
+  it("system: 設定変更で .dark クラスがリロードなしに切り替わる", () => {
     const mq = makeMediaQuery(false);
     vi.spyOn(window, "matchMedia").mockReturnValue(
       mq as unknown as MediaQueryList,
     );
-    const { unmount } = renderHook(() => useTheme());
+    const { unmount } = renderHook(() => useTheme("system"));
 
     expect(document.documentElement.classList.contains("dark")).toBe(false);
 
@@ -64,6 +64,27 @@ describe("useTheme", () => {
     act(() => mq.fire(false));
     expect(document.documentElement.classList.contains("dark")).toBe(false);
 
+    unmount();
+  });
+
+  it("dark: 常に .dark クラスが付く", () => {
+    const mq = makeMediaQuery(false);
+    vi.spyOn(window, "matchMedia").mockReturnValue(
+      mq as unknown as MediaQueryList,
+    );
+    const { unmount } = renderHook(() => useTheme("dark"));
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    unmount();
+  });
+
+  it("light: 常に .dark クラスが付かない", () => {
+    document.documentElement.classList.add("dark");
+    const mq = makeMediaQuery(true);
+    vi.spyOn(window, "matchMedia").mockReturnValue(
+      mq as unknown as MediaQueryList,
+    );
+    const { unmount } = renderHook(() => useTheme("light"));
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
     unmount();
   });
 });

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,7 +1,16 @@
 import { useEffect } from "react";
+import type { Theme } from "@/schemas/appSettings";
 
-export function useTheme(): void {
+export function useTheme(theme: Theme): void {
   useEffect(() => {
+    if (theme === "light") {
+      document.documentElement.classList.remove("dark");
+      return;
+    }
+    if (theme === "dark") {
+      document.documentElement.classList.add("dark");
+      return;
+    }
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const apply = ({ matches }: { matches: boolean }) => {
       document.documentElement.classList.toggle("dark", matches);
@@ -9,5 +18,5 @@ export function useTheme(): void {
     apply(mq);
     mq.addEventListener("change", apply);
     return () => mq.removeEventListener("change", apply);
-  }, []);
+  }, [theme]);
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,9 +1,11 @@
 import { createRootRoute, Outlet } from "@tanstack/react-router";
 import { BottomTabBar } from "@/components/BottomTabBar";
+import { useAppSettings } from "@/hooks/useAppSettings";
 import { useTheme } from "@/hooks/useTheme";
 
 function RootComponent() {
-  useTheme();
+  const { data: settings } = useAppSettings();
+  useTheme(settings?.theme ?? "system");
   return (
     <div
       style={{

--- a/src/schemas/appSettings.ts
+++ b/src/schemas/appSettings.ts
@@ -1,9 +1,13 @@
 import { z } from "zod";
 
+export const ThemeSchema = z.enum(["system", "light", "dark"]);
+export type Theme = z.infer<typeof ThemeSchema>;
+
 export const AppSettingsSchema = z.object({
   locationLat: z.number().min(-90).max(90).nullable(),
   locationLon: z.number().min(-180).max(180).nullable(),
   locationLabel: z.string(),
+  theme: ThemeSchema.default("system"),
 });
 
 export type AppSettings = z.infer<typeof AppSettingsSchema>;
@@ -12,4 +16,5 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   locationLat: null,
   locationLon: null,
   locationLabel: "",
+  theme: "system",
 };


### PR DESCRIPTION
## Summary

- 設定画面「外観」セクションにシステム／ライト／ダークの3択切替UIを追加
- `AppSettingsSchema` に `theme` フィールドを追加し localStorage に永続化
- `useTheme(theme)` をパラメータ受け取り形式に変更（`system` はデバイス追従を継続）
- ハードコードされた固定色をダークモード対応に修正
  - アクティブチップ文字色: `#fff` → `var(--background)`
  - バッジ背景: パステル固定色 → `rgba()` 半透明
  - カードシャドウ: `rgba(28,23,20,...)` → `rgba(0,0,0,...)`
  - モーダルオーバーレイ: `rgba(28,23,20,0.4)` → `rgba(0,0,0,0.5)`
  - フォームバリデーションエラー色: `#B83232` → `var(--destructive)`

## Test plan

- [x] 設定画面 → 外観セクションで「ライト」を選択 → 強制ライトモードになる
- [x] 「ダーク」を選択 → 強制ダークモードになる
- [x] 「システム」を選択 → デバイス設定に追従する
- [x] ページをリロードしても選択が保持される
- [x] ダークモードでフィルターチップ選択時のテキストが見やすい
- [x] ダークモードでバッジ（要確認・ベスト・残りわずか）が視認できる
- [x] `npm run test:run` が全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * テーマ設定機能を追加。システム・ライト・ダークモードを「設定」から選択可能に

* **改善**
  * 各コンポーネントの配色とシャドウを調整し、視覚的な統一性を向上
  * チャートツールチップの表示スタイルを改善
  * レーダーチャートで実際のテイスティングログに応じた動的表示に対応
  * フォームエラー表示の色をテーマ変数に統一

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otufor/RoastLog/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->